### PR TITLE
Add support of many PIL/Pillow formats

### DIFF
--- a/src/archive.py
+++ b/src/archive.py
@@ -14,12 +14,12 @@ except ImportError:
 import gtk
 
 import process
+from image import get_supported_format_extensions_preg
 
 ZIP, RAR, TAR, GZIP, BZIP2, SEVENZIP = range(6)
 
 _rar_exec = None
 _7z_exec = None
-
 
 class Extractor:
 
@@ -417,7 +417,7 @@ def get_archive_info(path):
     """Return a tuple (mime, num_pages, size) with info about the archive
     at <path>, or None if <path> doesn't point to a supported archive.
     """
-    image_re = re.compile(r'\.(jpg|jpeg|png|gif|tif|tiff|bmp)\s*$', re.I)
+    image_re = re.compile('\.('+'|'.join(get_supported_format_extensions_preg())+')\s*$', re.I)
     extractor = Extractor()
     extractor.setup(path, None)
     mime = extractor.get_mime_type()

--- a/src/filehandler.py
+++ b/src/filehandler.py
@@ -18,7 +18,7 @@ import encoding
 import image
 from preferences import prefs
 import thumbnail
-
+from image import get_supported_format_extensions_preg
 
 class FileHandler:
 
@@ -47,7 +47,9 @@ class FileHandler:
         self._name_table = {}
         self._extractor = archive.Extractor()
         self._condition = None
-        self._image_re = re.compile(r'\.(jpg|jpeg|png|gif|tif|tiff|bmp)\s*$', re.I)
+
+        self._image_re = re.compile('\.('+'|'.join(get_supported_format_extensions_preg())+')\s*$', re.I)
+
         self.update_comment_extensions()
 
     def _get_pixbuf(self, index):

--- a/src/image.py
+++ b/src/image.py
@@ -8,6 +8,39 @@ import ImageStat
 
 from preferences import prefs
 
+def get_supported_format_extensions_preg():
+    """
+    Return list of image extensions for ues in REGEX
+
+    PIL 1.1.7 can support not only common image formats
+    """
+
+    formats = [
+        "jpg", "jpeg?",
+        "png",
+        "bmp",
+        "tiff?",
+        "gif",
+        "eps", "dcx", "msp",
+        "pcx", "ppm", "xbm", "xpm",
+        "cur", "ico", "fl[ic]",
+        "pcd", "psd", "tga",
+        "fpx", "wal", "sgi"
+    ]
+    try:
+        import Image
+        if hasattr(Image, "PILLOW_VERSION"):
+            # It's PIL fork with more image formats
+            # like Jpeg2000, WebP
+            # Support status is unknown. We can only try to load images...
+            formats.extend([
+                "j2[kp]", "jp[2x]",
+                "webp"
+            ])
+    except:
+        pass
+    return formats
+
 
 def fit_in_rectangle(src, width, height, scale_up=False, rotation=0,
   animated=False):

--- a/src/thumbnail.py
+++ b/src/thumbnail.py
@@ -21,6 +21,8 @@ import archive
 import constants
 import filehandler
 
+from image import get_supported_format_extensions_preg
+
 _thumbdir = os.path.join(constants.HOME_DIR, '.thumbnails/normal')
 
 
@@ -201,7 +203,9 @@ def _guess_cover(files):
     cover of an archive using some simple heuristics.
     """
     filehandler.alphanumeric_sort(files)
-    ext_re = re.compile(r'\.(jpg|jpeg|png|gif|tif|tiff|bmp)\s*$', re.I)
+
+    ext_re = re.compile('\.('+'|'.join(get_supported_format_extensions_preg())+')\s*$', re.I)
+
     front_re = re.compile('(cover|front)', re.I)
     images = filter(ext_re.search, files)
     candidates = filter(front_re.search, images)


### PR DESCRIPTION
PIL or Pillow can read not only common image formats but many old or new.
