### PR TITLE
Format strings

### DIFF
--- a/install.py
+++ b/install.py
@@ -299,13 +299,12 @@ if args == ['install']:
             install(src, dst)
         for src, link in MIME_LINKS:
             make_link(src, link)
-        os.popen('update-mime-database "%s"' %
-                 os.path.join(install_dir, 'share/mime'))
+        os.popen('update-mime-database "{}"'.format(os.path.join(install_dir, 'share/mime')))
         print('\nUpdated mime database (added .cbz, .cbr and .cbt file types.)')
         schema = os.path.join(source_dir, 'mime/comicbook.schemas')
         os.popen('GCONF_CONFIG_SOURCE=$(gconftool-2 --get-default-source) '
-                 'gconftool-2 --makefile-install-rule "%s" 2>/dev/null' %
-                 schema)
+                 'gconftool-2 --makefile-install-rule "{}" 2>/dev/null'
+                 .format(schema))
         print('\nRegistered comic archive thumbnailer in gconf (if available).')
         print('The thumbnailer is only supported by some file '
               'managers such as Nautilus and Thunar. You might'

--- a/messages/ca/LC_MESSAGES/comix.po
+++ b/messages/ca/LC_MESSAGES/comix.po
@@ -652,8 +652,7 @@ msgid ""
 "Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Col·loca la col·lecció '{subcollection}' en la col·lecció '%"
-"(supercollection)s'."
+"Col·loca la col·lecció '{subcollection}' en la col·lecció '{supercollection}'."
 
 #
 # File: src/library.py, line: 407

--- a/messages/ca/LC_MESSAGES/comix.po
+++ b/messages/ca/LC_MESSAGES/comix.po
@@ -288,8 +288,8 @@ msgstr "Comentaris"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "No s'ha pogut llegir %s"
+msgid "Could not read {}"
+msgstr "No s'ha pogut llegir {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -476,8 +476,8 @@ msgstr "Arxius tar"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Ja existeix un fitxer anomenat '%s'. Voleu substituir-lo?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Ja existeix un fitxer anomenat '{}'. Voleu substituir-lo?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -516,36 +516,36 @@ msgstr "Afegeix automàticament els llibres a aquesta colecció"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "No s'ha pogut obrir %s: És un directori."
+msgid "Could not open {}: Is a directory."
+msgstr "No s'ha pogut obrir {}: És un directori."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "No s'ha pogut obrir %s: No existeix el fitxer."
+msgid "Could not open {}: No such file."
+msgstr "No s'ha pogut obrir {}: No existeix el fitxer."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "No s'ha pogut obrir %s: S'ha denegat el permís."
+msgid "Could not open {}: Permission denied."
+msgstr "No s'ha pogut obrir {}: S'ha denegat el permís."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "No s'ha pogut obrir %s: Tipus de fitxer desconegut."
+msgid "Could not open {}: Unknown file type."
+msgstr "No s'ha pogut obrir {}: Tipus de fitxer desconegut."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "No hi ha imatges a '%s'"
+msgid "No images in '{}'"
+msgstr "No hi ha imatges a '{}'"
 
 #
 # File: src/filehandler.py, line: 411
@@ -622,8 +622,8 @@ msgstr "Introduïu un nom nou per a la col·lecció seleccionada."
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "No s'ha pogut canviar el nom a '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "No s'ha pogut canviar el nom a '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -649,27 +649,27 @@ msgstr "Arrel"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Col·loca la col·lecció '%(subcollection)s' en la col·lecció '%"
+"Col·loca la col·lecció '{subcollection}' en la col·lecció '%"
 "(supercollection)s'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Afegeix llibres a '%s'."
+msgid "Add books to '{}'."
+msgstr "Afegeix llibres a '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Mou els llibres de '%(source collection)s' a '%(destination collection)s'."
+"Mou els llibres de '{source collection}' a '{destination collection}'."
 
 #
 # File: src/library.py, line: 492
@@ -687,8 +687,8 @@ msgstr "Elimina de la biblioteca..."
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "S'han esborrat %(num)d llibres de '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "S'han esborrat {num} llibres de '{collection}'."
 
 #
 # File: src/library.py, line: 597
@@ -710,8 +710,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "S'han esborrat %d llibres de la biblioteca."
+msgid "Removed {} book(s) from the library."
+msgstr "S'han esborrat {} llibres de la biblioteca."
 
 #
 # File: src/library.py, line: 769
@@ -770,8 +770,8 @@ msgstr "Obre el llibre seleccionat."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d pàgines"
+msgid "{} pages"
+msgstr "{} pàgines"
 
 #
 # File: src/library.py, line: 854
@@ -795,8 +795,8 @@ msgstr "Nova col·lecció"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "No s'ha pogut afegir una nova col·lecció amb el nom '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "No s'ha pogut afegir una nova col·lecció amb el nom '{}'."
 
 #
 # File: src/library.py, line: 910
@@ -814,8 +814,8 @@ msgstr "Llibres afegits"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Afegint '%s'..."
+msgid "Adding '{}'..."
+msgstr "Afegint '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -1278,8 +1278,8 @@ msgstr "Propietats"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d comentaris"
+msgid "{} comments"
+msgstr "{} comentaris"
 
 #
 # File: src/properties.py, line: 124
@@ -1415,8 +1415,8 @@ msgstr "Mida total de les miniatures esborrades"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "S'ha esborrat la miniatura de '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "S'ha esborrat la miniatura de '{}'"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/cs/LC_MESSAGES/comix.po
+++ b/messages/cs/LC_MESSAGES/comix.po
@@ -285,8 +285,8 @@ msgstr "Komentáře"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "%s nelze načíst"
+msgid "Could not read {}"
+msgstr "{} nelze načíst"
 
 #
 # File: src/deprecated.py, line: 16
@@ -473,8 +473,8 @@ msgstr "Archivy TAR"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Soubor jménem „%s“ již existuje. Přejete si jej nahradit?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Soubor jménem „{}“ již existuje. Přejete si jej nahradit?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -513,36 +513,36 @@ msgstr "Automaticky přidat knihy do této sbírky"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Nelze otevřít %s: Je to složka"
+msgid "Could not open {}: Is a directory."
+msgstr "Nelze otevřít {}: Je to složka"
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Nelze otevřít %s: Soubor neexistuje."
+msgid "Could not open {}: No such file."
+msgstr "Nelze otevřít {}: Soubor neexistuje."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Nelze otevřít %s: Přístup odmítnut."
+msgid "Could not open {}: Permission denied."
+msgstr "Nelze otevřít {}: Přístup odmítnut."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Nelze otevřít %s: Neznámý typ souboru."
+msgid "Could not open {}: Unknown file type."
+msgstr "Nelze otevřít {}: Neznámý typ souboru."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "„%s“ neobsahuje žádné obrázky"
+msgid "No images in '{}'"
+msgstr "„{}“ neobsahuje žádné obrázky"
 
 #
 # File: src/filehandler.py, line: 411
@@ -619,8 +619,8 @@ msgstr "Prosím vložte nové jméno vybrané sbírky."
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Nelze změnit jméno na „%s“."
+msgid "Could not change the name to '{}'."
+msgstr "Nelze změnit jméno na „{}“."
 
 #
 # File: src/library.py, line: 275
@@ -646,25 +646,25 @@ msgstr "Kořen"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "Vložit sbírku „%(subcollection)s“ do sbírky „%(supercollection)s“."
+msgstr "Vložit sbírku „{subcollection}“ do sbírky „{supercollection}“."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Přidat knihy do „%s“."
+msgid "Add books to '{}'."
+msgstr "Přidat knihy do „{}“."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Přesunout knihy z „%(source collection)s“ do „%(destination collection)s“."
+"Přesunout knihy z „{source collection}“ do „{destination collection}“."
 
 #
 # File: src/library.py, line: 492
@@ -682,8 +682,8 @@ msgstr "Odstranit z knihovny…"
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Odstraněno %(num)d knih ze sbírky „%(collection)s“."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Odstraněno {num} knih ze sbírky „{collection}“."
 
 #
 # File: src/library.py, line: 597
@@ -705,8 +705,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Odstraněno %d knih z knihovny."
+msgid "Removed {} book(s) from the library."
+msgstr "Odstraněno {} knih z knihovny."
 
 #
 # File: src/library.py, line: 769
@@ -765,8 +765,8 @@ msgstr "Otevřít vybranou knihu."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d stránek"
+msgid "{} pages"
+msgstr "{} stránek"
 
 #
 # File: src/library.py, line: 854
@@ -790,8 +790,8 @@ msgstr "Nová sbírka"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Nelze přidat novou sbírku jménem „%s“."
+msgid "Could not add a new collection called '{}'."
+msgstr "Nelze přidat novou sbírku jménem „{}“."
 
 #
 # File: src/library.py, line: 910
@@ -809,8 +809,8 @@ msgstr "Přidané knihy"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Přidává se „%s“…"
+msgid "Adding '{}'..."
+msgstr "Přidává se „{}“…"
 
 #
 # File: src/main.py, line: 666
@@ -1267,8 +1267,8 @@ msgstr "Vlastnosti"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d komentářů"
+msgid "{} comments"
+msgstr "{} komentářů"
 
 #
 # File: src/properties.py, line: 124
@@ -1404,8 +1404,8 @@ msgstr "Celková velikost odstraněných náhledů"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Odstraněn náhled pro „%s“"
+msgid "Removed thumbnail for '{}'"
+msgstr "Odstraněn náhled pro „{}“"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/de/LC_MESSAGES/comix.po
+++ b/messages/de/LC_MESSAGES/comix.po
@@ -196,8 +196,8 @@ msgstr "Kommentare"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "%s kann nicht gelesen werden"
+msgid "Could not read {}"
+msgstr "{} kann nicht gelesen werden"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -329,9 +329,9 @@ msgstr "Tar-Archive"
 
 #: src/filechooser.py:134
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
 msgstr ""
-"Eine Datei mit dem Namen »%s« existiert bereits. Möchten Sie sie ersetzen?"
+"Eine Datei mit dem Namen »{}« existiert bereits. Möchten Sie sie ersetzen?"
 
 #: src/filechooser.py:137
 msgid "Replacing it will overwrite its contents."
@@ -355,28 +355,28 @@ msgstr "Die Bücher automatisch zu dieser Sammlung hinzufügen"
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "%s kann nicht geöffnet werden: Es ist ein Verzeichnis."
+msgid "Could not open {}: Is a directory."
+msgstr "{} kann nicht geöffnet werden: Es ist ein Verzeichnis."
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "%s kann nicht geöffnet werden: Datei nicht gefunden."
+msgid "Could not open {}: No such file."
+msgstr "{} kann nicht geöffnet werden: Datei nicht gefunden."
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "%s kann nicht geöffnet werden: Zugriff verweigert."
+msgid "Could not open {}: Permission denied."
+msgstr "{} kann nicht geöffnet werden: Zugriff verweigert."
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "%s kann nicht geöffnet werden: Unbekannter Dateityp."
+msgid "Could not open {}: Unknown file type."
+msgstr "{} kann nicht geöffnet werden: Unbekannter Dateityp."
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Keine Bilder in »%s«"
+msgid "No images in '{}'"
+msgstr "Keine Bilder in »{}«"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -429,8 +429,8 @@ msgstr "Bitte geben Sie einen neuen Namen für die ausgewählte Sammlung ein."
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Name konnte nicht zu »%s« geändert werden."
+msgid "Could not change the name to '{}'."
+msgstr "Name konnte nicht zu »{}« geändert werden."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
@@ -447,23 +447,23 @@ msgstr "Wurzel"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Die Sammlung »%(subcollection)s« in die Sammlung »%(supercollection)s« "
+"Die Sammlung »{subcollection}« in die Sammlung »{supercollection}« "
 "stellen."
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Bücher zu »%s« hinzufügen."
+msgid "Add books to '{}'."
+msgstr "Bücher zu »{}« hinzufügen."
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Bücher von »%(source collection)s« nach »%(destination collection)s« "
+"Bücher von »{source collection}« nach »{destination collection}« "
 "verschieben."
 
 #: src/library.py:493
@@ -476,8 +476,8 @@ msgstr "Aus dieser Bibliothek entfernen ..."
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "%(num)d Buch(Bücher) wurden aus »%(collection)s« entfernt."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "{num} Buch(Bücher) wurden aus »{collection}« entfernt."
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -494,8 +494,8 @@ msgstr ""
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "%d Buch(Bücher) wurden aus der Bibliothek entfernt."
+msgid "Removed {} book(s) from the library."
+msgstr "{} Buch(Bücher) wurden aus der Bibliothek entfernt."
 
 #: src/library.py:770
 msgid "Search"
@@ -536,8 +536,8 @@ msgstr "Das ausgewählte Buch öffnen."
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d Seiten"
+msgid "{} pages"
+msgstr "{} Seiten"
 
 #: src/library.py:855
 msgid "Add new collection?"
@@ -553,8 +553,8 @@ msgstr "Neue Sammlung"
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Eine neue Sammlung mit Namen »%s« konnte nicht hinzugefügt werden."
+msgid "Could not add a new collection called '{}'."
+msgstr "Eine neue Sammlung mit Namen »{}« konnte nicht hinzugefügt werden."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -566,8 +566,8 @@ msgstr "Hinzugefügte Bücher"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Füge »%s« hinzu ..."
+msgid "Adding '{}'..."
+msgstr "Füge »{}« hinzu ..."
 
 #: src/main.py:699
 msgid "SLIDESHOW"
@@ -911,8 +911,8 @@ msgstr "Eigenschaften"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d Kommentare"
+msgid "{} comments"
+msgstr "{} Kommentare"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -1004,8 +1004,8 @@ msgstr "Gesamtgröße der entfernten Vorschaubilder"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Vorschaubild für »%s« wurde entfernt"
+msgid "Removed thumbnail for '{}'"
+msgstr "Vorschaubild für »{}« wurde entfernt"
 
 #: src/ui.py:34
 msgid "_Next page"

--- a/messages/el/LC_MESSAGES/comix.po
+++ b/messages/el/LC_MESSAGES/comix.po
@@ -283,7 +283,7 @@ msgstr "Σχόλια"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
+msgid "Could not read {}"
 msgstr ""
 
 #
@@ -463,7 +463,7 @@ msgstr ""
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
 msgstr ""
 
 #
@@ -503,35 +503,35 @@ msgstr ""
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
+msgid "Could not open {}: Is a directory."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
+msgid "Could not open {}: No such file."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
+msgid "Could not open {}: Permission denied."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
+msgid "Could not open {}: Unknown file type."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
+msgid "No images in '{}'"
 msgstr ""
 
 #
@@ -607,7 +607,7 @@ msgstr ""
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
+msgid "Could not change the name to '{}'."
 msgstr ""
 
 #
@@ -634,7 +634,7 @@ msgstr ""
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr ""
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
+msgid "Add books to '{}'."
 msgstr ""
 
 #
@@ -650,7 +650,7 @@ msgstr ""
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
 
 #
@@ -669,7 +669,7 @@ msgstr ""
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
 msgstr ""
 
 #
@@ -690,7 +690,7 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
+msgid "Removed {} book(s) from the library."
 msgstr ""
 
 #
@@ -748,7 +748,7 @@ msgstr ""
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
+msgid "{} pages"
 msgstr ""
 
 #
@@ -773,7 +773,7 @@ msgstr ""
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
+msgid "Could not add a new collection called '{}'."
 msgstr ""
 
 #
@@ -792,7 +792,7 @@ msgstr ""
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
+msgid "Adding '{}'..."
 msgstr ""
 
 #
@@ -1219,7 +1219,7 @@ msgstr "Ιδιότητες"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
+msgid "{} comments"
 msgstr ""
 
 #
@@ -1351,7 +1351,7 @@ msgstr ""
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
+msgid "Removed thumbnail for '{}'"
 msgstr ""
 
 #
@@ -1685,8 +1685,8 @@ msgid "Magnifying glass"
 msgstr ""
 
 #
-#~ msgid "No images in \"%s\""
-#~ msgstr "Όχι εικόνες σε \"%s\""
+#~ msgid "No images in \"{}\""
+#~ msgstr "Όχι εικόνες σε \"{}\""
 
 #
 #~ msgid "Default"
@@ -2087,12 +2087,12 @@ msgstr ""
 #~ msgstr "Επιβεβαίωση λειτουργίας"
 
 #
-#~ msgid "Permanently remove %s?"
-#~ msgstr "Μόνιμη διαγραφή %s;"
+#~ msgid "Permanently remove {}?"
+#~ msgstr "Μόνιμη διαγραφή {};"
 
 #
-#~ msgid "Perform lossless JPEG operation on %s?"
-#~ msgstr "Εκτέλεση λειτουργίας χωρίς απώλειες εικόνας JPEG  σε %s; "
+#~ msgid "Perform lossless JPEG operation on {}?"
+#~ msgstr "Εκτέλεση λειτουργίας χωρίς απώλειες εικόνας JPEG  σε {}; "
 
 #
 #~ msgid "Some images might be trimmed a bit during the operation."
@@ -2101,8 +2101,8 @@ msgstr ""
 #~ "λειτουργίας"
 
 #
-#~ msgid "Permanently convert %s to greyscale?"
-#~ msgstr "Μόνιμη μετατροπή %s σε ασπρόμαυρη εικόνα συνεχών τόνων του γκρί;"
+#~ msgid "Permanently convert {} to greyscale?"
+#~ msgstr "Μόνιμη μετατροπή {} σε ασπρόμαυρη εικόνα συνεχών τόνων του γκρί;"
 
 #
 #~ msgid "Location:"

--- a/messages/es/LC_MESSAGES/comix.po
+++ b/messages/es/LC_MESSAGES/comix.po
@@ -657,8 +657,7 @@ msgid ""
 "Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Coloca la colección '{subcollection}' dentro de la colección '%"
-"(supercollection)s'."
+"Coloca la colección '{subcollection}' dentro de la colección '{supercollection}'."
 
 #
 # File: src/library.py, line: 407
@@ -674,8 +673,7 @@ msgstr "Agregar libros a '{}'."
 msgid ""
 "Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Mover libros desde la colección '{source collection}' hacia la colección '%"
-"(destination collection)s'."
+"Mover libros desde la colección '{source collection}' hacia la colección '{destination collection}'."
 
 #
 # File: src/library.py, line: 492

--- a/messages/es/LC_MESSAGES/comix.po
+++ b/messages/es/LC_MESSAGES/comix.po
@@ -292,8 +292,8 @@ msgstr "Comentarios"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "No se puede leer %s"
+msgid "Could not read {}"
+msgstr "No se puede leer {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -481,8 +481,8 @@ msgstr "Archivos Tar"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Ya existe un archivo de nombre '%s'. ¿Desea reemplazarlo?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Ya existe un archivo de nombre '{}'. ¿Desea reemplazarlo?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -521,36 +521,36 @@ msgstr "Agregar automáticamente los libros a esta colección"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "No se puede abrir %s: es un directorio."
+msgid "Could not open {}: Is a directory."
+msgstr "No se puede abrir {}: es un directorio."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "No se puede abrir %s: el archivo no existe."
+msgid "Could not open {}: No such file."
+msgstr "No se puede abrir {}: el archivo no existe."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "No se puede abrir %s: permiso denegado."
+msgid "Could not open {}: Permission denied."
+msgstr "No se puede abrir {}: permiso denegado."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "No se puede abrir %s: tipo de archivo desconocido."
+msgid "Could not open {}: Unknown file type."
+msgstr "No se puede abrir {}: tipo de archivo desconocido."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "No hay imágenes en '%s'"
+msgid "No images in '{}'"
+msgstr "No hay imágenes en '{}'"
 
 #
 # File: src/filehandler.py, line: 411
@@ -627,8 +627,8 @@ msgstr "Ingrese un nombre nuevo para la colección seleccionada."
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "No se puede cambiar el nombre a '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "No se puede cambiar el nombre a '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -654,27 +654,27 @@ msgstr "Raíz"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Coloca la colección '%(subcollection)s' dentro de la colección '%"
+"Coloca la colección '{subcollection}' dentro de la colección '%"
 "(supercollection)s'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Agregar libros a '%s'."
+msgid "Add books to '{}'."
+msgstr "Agregar libros a '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Mover libros desde la colección '%(source collection)s' hacia la colección '%"
+"Mover libros desde la colección '{source collection}' hacia la colección '%"
 "(destination collection)s'."
 
 #
@@ -693,8 +693,8 @@ msgstr "Quitar de la biblioteca..."
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Se han quitado %(num)d libro(s) desde '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Se han quitado {num} libro(s) desde '{collection}'."
 
 #
 # File: src/library.py, line: 597
@@ -716,8 +716,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Se han quitado %d libro(s) de la biblioteca."
+msgid "Removed {} book(s) from the library."
+msgstr "Se han quitado {} libro(s) de la biblioteca."
 
 #
 # File: src/library.py, line: 769
@@ -776,8 +776,8 @@ msgstr "Abrir el libro seleccionado."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d páginas"
+msgid "{} pages"
+msgstr "{} páginas"
 
 #
 # File: src/library.py, line: 854
@@ -801,8 +801,8 @@ msgstr "Nueva colección"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "No se puede agregar una nueva colección llamada '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "No se puede agregar una nueva colección llamada '{}'."
 
 #
 # File: src/library.py, line: 910
@@ -820,8 +820,8 @@ msgstr "Libros agregados"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Agregando '%s'..."
+msgid "Adding '{}'..."
+msgstr "Agregando '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -1286,8 +1286,8 @@ msgstr "Propiedades"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d comentarios"
+msgid "{} comments"
+msgstr "{} comentarios"
 
 #
 # File: src/properties.py, line: 124
@@ -1424,8 +1424,8 @@ msgstr "Tamaño total de miniaturas eliminadas"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Se eliminó la miniatura para '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Se eliminó la miniatura para '{}'"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/fa/LC_MESSAGES/comix.po
+++ b/messages/fa/LC_MESSAGES/comix.po
@@ -283,7 +283,7 @@ msgstr "توضیحات"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
+msgid "Could not read {}"
 msgstr ""
 
 #
@@ -463,7 +463,7 @@ msgstr ""
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
 msgstr ""
 
 #
@@ -503,35 +503,35 @@ msgstr ""
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
+msgid "Could not open {}: Is a directory."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
+msgid "Could not open {}: No such file."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
+msgid "Could not open {}: Permission denied."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
+msgid "Could not open {}: Unknown file type."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
+msgid "No images in '{}'"
 msgstr ""
 
 #
@@ -607,7 +607,7 @@ msgstr ""
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
+msgid "Could not change the name to '{}'."
 msgstr ""
 
 #
@@ -634,7 +634,7 @@ msgstr ""
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr ""
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
+msgid "Add books to '{}'."
 msgstr ""
 
 #
@@ -650,7 +650,7 @@ msgstr ""
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
 
 #
@@ -669,7 +669,7 @@ msgstr ""
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
 msgstr ""
 
 #
@@ -690,7 +690,7 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
+msgid "Removed {} book(s) from the library."
 msgstr ""
 
 #
@@ -748,7 +748,7 @@ msgstr ""
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
+msgid "{} pages"
 msgstr ""
 
 #
@@ -773,7 +773,7 @@ msgstr ""
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
+msgid "Could not add a new collection called '{}'."
 msgstr ""
 
 #
@@ -792,7 +792,7 @@ msgstr ""
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
+msgid "Adding '{}'..."
 msgstr ""
 
 #
@@ -1219,7 +1219,7 @@ msgstr "ویژگی‌ها"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
+msgid "{} comments"
 msgstr ""
 
 #
@@ -1351,7 +1351,7 @@ msgstr ""
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
+msgid "Removed thumbnail for '{}'"
 msgstr ""
 
 #
@@ -1685,8 +1685,8 @@ msgid "Magnifying glass"
 msgstr ""
 
 #
-#~ msgid "No images in \"%s\""
-#~ msgstr "هیچ تصویری در «%s» نیست."
+#~ msgid "No images in \"{}\""
+#~ msgstr "هیچ تصویری در «{}» نیست."
 
 #
 #~ msgid "Default"
@@ -2083,20 +2083,20 @@ msgstr ""
 #~ msgstr "تأیید عملیات"
 
 #
-#~ msgid "Permanently remove %s?"
-#~ msgstr "%s برای همیشه حذف شود؟"
+#~ msgid "Permanently remove {}?"
+#~ msgstr "{} برای همیشه حذف شود؟"
 
 #
-#~ msgid "Perform lossless JPEG operation on %s?"
-#~ msgstr "عملیات JPEG بی‌خسارت روی %s انجام شود؟"
+#~ msgid "Perform lossless JPEG operation on {}?"
+#~ msgstr "عملیات JPEG بی‌خسارت روی {} انجام شود؟"
 
 #
 #~ msgid "Some images might be trimmed a bit during the operation."
 #~ msgstr "ممکن است در طول عملیات حاشیهٔ بعضی تصاویر کمی بریده شوند."
 
 #
-#~ msgid "Permanently convert %s to greyscale?"
-#~ msgstr "%s برای همیشه به سایه‌خاکستری تبدیل شود؟"
+#~ msgid "Permanently convert {} to greyscale?"
+#~ msgstr "{} برای همیشه به سایه‌خاکستری تبدیل شود؟"
 
 #
 #~ msgid "Location:"

--- a/messages/fr/LC_MESSAGES/comix.po
+++ b/messages/fr/LC_MESSAGES/comix.po
@@ -449,8 +449,7 @@ msgid ""
 "Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Mettre la collection '{subcollection}' dans la collection '%"
-"(supercollection)s'."
+"Mettre la collection '{subcollection}' dans la collection '{supercollection}'."
 
 #: src/library.py:407
 #, python-format

--- a/messages/fr/LC_MESSAGES/comix.po
+++ b/messages/fr/LC_MESSAGES/comix.po
@@ -197,8 +197,8 @@ msgstr "Commentaires"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Impossible de lire %s"
+msgid "Could not read {}"
+msgstr "Impossible de lire {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -329,8 +329,8 @@ msgstr "Archives Tar"
 
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Un fichier nommé '%s' existe déjà. Voulez-vous le remplacer ?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Un fichier nommé '{}' existe déjà. Voulez-vous le remplacer ?"
 
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
@@ -354,28 +354,28 @@ msgstr "Ajouter automatiquement les livres à cette collection"
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Impossible d'ouvrir %s: C'est un répertoire."
+msgid "Could not open {}: Is a directory."
+msgstr "Impossible d'ouvrir {}: C'est un répertoire."
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Impossible d'ouvrir %s: Fichier inexistant."
+msgid "Could not open {}: No such file."
+msgstr "Impossible d'ouvrir {}: Fichier inexistant."
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Impossible d'ouvrir %s: Permission refusée."
+msgid "Could not open {}: Permission denied."
+msgstr "Impossible d'ouvrir {}: Permission refusée."
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Impossible d'ouvrir %s: Type de fichier inconnu."
+msgid "Could not open {}: Unknown file type."
+msgstr "Impossible d'ouvrir {}: Type de fichier inconnu."
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Pas d'images dans '%s'"
+msgid "No images in '{}'"
+msgstr "Pas d'images dans '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -428,8 +428,8 @@ msgstr "Entrer un nouveau nom pour le collection sélectionnée."
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Impossible de changer le nom en '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Impossible de changer le nom en '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
@@ -446,24 +446,23 @@ msgstr "Racine"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Mettre la collection '%(subcollection)s' dans la collection '%"
+"Mettre la collection '{subcollection}' dans la collection '%"
 "(supercollection)s'."
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Ajouter le livre à '%s'."
+msgid "Add books to '{}'."
+msgstr "Ajouter le livre à '{}'."
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Déplacer les livres de '%(source collection)s' vers '%(destination "
-"collection)s'."
+"Déplacer les livres de '{source collection}' vers '{destination collection}'."
 
 #: src/library.py:493
 msgid "Remove from this collection"
@@ -475,8 +474,8 @@ msgstr "Supprimer de la bibliothèque..."
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "%(num)d livre(s) supprimés de '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "{num} livre(s) supprimés de '{collection}'."
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -492,8 +491,8 @@ msgstr ""
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "%d livre(s) supprimés de la bibliothèque."
+msgid "Removed {} book(s) from the library."
+msgstr "{} livre(s) supprimés de la bibliothèque."
 
 #: src/library.py:770
 msgid "Search"
@@ -533,8 +532,8 @@ msgstr "Ouvrir le livre sélectionné."
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d pages"
+msgid "{} pages"
+msgstr "{} pages"
 
 #: src/library.py:855
 msgid "Add new collection?"
@@ -550,8 +549,8 @@ msgstr "Nouvelle collection"
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Impossible d'ajouter une nouvelle collection appelée '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Impossible d'ajouter une nouvelle collection appelée '{}'."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -563,8 +562,8 @@ msgstr "Livres ajoutés"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Ajout de '%s'..."
+msgid "Adding '{}'..."
+msgstr "Ajout de '{}'..."
 
 #: src/main.py:704
 msgid "SLIDESHOW"
@@ -900,8 +899,8 @@ msgstr "Propriétés"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d commentaires"
+msgid "{} comments"
+msgstr "{} commentaires"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -991,8 +990,8 @@ msgstr "Taille totale des vignettes supprimées"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Vignette supprimée pour '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Vignette supprimée pour '{}'"
 
 #: src/ui.py:34
 msgid "_Next page"

--- a/messages/gl/LC_MESSAGES/comix.po
+++ b/messages/gl/LC_MESSAGES/comix.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: Marcelo Góes <vanquirius@gentoo.org>\n"
+"Last-Translator: Marcelo Gï¿½es <vanquirius@gentoo.org>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
@@ -16,16 +16,16 @@ msgstr "Sobre"
 #: src/about.py:56
 msgid "Comix is an image viewer specifically designed to handle comic books."
 msgstr ""
-"Comix é un visualizador de imaxes deseñado especificamente para ler "
-"bandas deseñadas no seu ordenador."
+"Comix ï¿½ un visualizador de imaxes deseï¿½ado especificamente para ler "
+"bandas deseï¿½adas no seu ordenador."
 
 #: src/about.py:58
 msgid "It reads ZIP, RAR and tar archives, as well as plain image files."
-msgstr "Le arquivos ZIP, RAR e tar, así como imaxes normais."
+msgstr "Le arquivos ZIP, RAR e tar, asï¿½ como imaxes normais."
 
 #: src/about.py:60
 msgid "Comix is licensed under the GNU General Public License."
-msgstr "Comix publícase baixo a GNU General Public License."
+msgstr "Comix publï¿½case baixo a GNU General Public License."
 
 #: src/about.py:83
 msgid "Developer"
@@ -33,91 +33,91 @@ msgstr "Programador"
 
 #: src/about.py:84 src/about.py:85
 msgid "Simplified Chinese translation"
-msgstr "Tradución ao chinés simplificado"
+msgstr "Traduciï¿½n ao chinï¿½s simplificado"
 
 #: src/about.py:86
 msgid "Spanish translation"
-msgstr "Tradución ao castelán"
+msgstr "Traduciï¿½n ao castelï¿½n"
 
 #: src/about.py:87
 msgid "Brazilian Portuguese translation"
-msgstr "Tradución ao portugués do Brasil"
+msgstr "Traduciï¿½n ao portuguï¿½s do Brasil"
 
 #: src/about.py:88
 msgid "German translation and Nautilus thumbnailer"
-msgstr "Tradución ao alemán e thumbnailer do Nautilus"
+msgstr "Traduciï¿½n ao alemï¿½n e thumbnailer do Nautilus"
 
 #: src/about.py:89 src/about.py:90
 msgid "Italian translation"
-msgstr "Tradución ao italiano"
+msgstr "Traduciï¿½n ao italiano"
 
 #: src/about.py:91
 msgid "Dutch translation"
-msgstr "Tradución ao holandés"
+msgstr "Traduciï¿½n ao holandï¿½s"
 
 #: src/about.py:92
 msgid "French translation"
-msgstr "Tradución ao francés"
+msgstr "Traduciï¿½n ao francï¿½s"
 
 #: src/about.py:93 src/about.py:94
 msgid "Polish translation"
-msgstr "Tradución ao polaco"
+msgstr "Traduciï¿½n ao polaco"
 
 #: src/about.py:95
 msgid "Greek translation"
-msgstr "Tradución ao grego"
+msgstr "Traduciï¿½n ao grego"
 
 #: src/about.py:96
 msgid "Catalan translation"
-msgstr "Tradución ao catalán"
+msgstr "Traduciï¿½n ao catalï¿½n"
 
 #: src/about.py:97 src/about.py:98
 msgid "Traditional Chinese translation"
-msgstr "Tradución ao chinés tradicional"
+msgstr "Traduciï¿½n ao chinï¿½s tradicional"
 
 #: src/about.py:99
 msgid "Japanese translation"
-msgstr "Tradución ao xaponés"
+msgstr "Traduciï¿½n ao xaponï¿½s"
 
 #: src/about.py:100
 msgid "Hungarian translation"
-msgstr "Tradución ao húngaro"
+msgstr "Traduciï¿½n ao hï¿½ngaro"
 
 #: src/about.py:101
 msgid "Russian translation"
-msgstr "Tradución ao ruso"
+msgstr "Traduciï¿½n ao ruso"
 
 #: src/about.py:102
 msgid "Croatian translation"
-msgstr "Tradución ao croata"
+msgstr "Traduciï¿½n ao croata"
 
 #: src/about.py:103
 msgid "Korean translation"
-msgstr "Tradución ao coreano"
+msgstr "Traduciï¿½n ao coreano"
 
 #: src/about.py:104
 msgid "Persian translation"
-msgstr "Tradución ao persa"
+msgstr "Traduciï¿½n ao persa"
 
 #: src/about.py:105
 msgid "Indonesian translation"
-msgstr "Tradución ao indonesio"
+msgstr "Traduciï¿½n ao indonesio"
 
 #: src/about.py:106
 msgid "Czech translation"
-msgstr "Tradución ao checo"
+msgstr "Traduciï¿½n ao checo"
 
 #: src/about.py:107
 msgid "Icon design"
-msgstr "Deseño das iconas"
+msgstr "Deseï¿½o das iconas"
 
 #: src/about.py:114
 msgid "Credits"
-msgstr "Créditos"
+msgstr "Crï¿½ditos"
 
 #: src/archive.py:66
 msgid "Could not find RAR file extractor!"
-msgstr "Non foi posíbel encontrar un programa para a extracción de arquivos RAR!"
+msgstr "Non foi posï¿½bel encontrar un programa para a extracciï¿½n de arquivos RAR!"
 
 #: src/archive.py:68
 msgid ""
@@ -167,7 +167,7 @@ msgstr "Eliminar todos os favoritos?"
 msgid ""
 "All stored bookmarks will be removed. Are you sure that you want to continue?"
 msgstr ""
-"Todos os favoritos gravados serán eliminados. Está seguro de que desexa "
+"Todos os favoritos gravados serï¿½n eliminados. Estï¿½ seguro de que desexa "
 "continuar?"
 
 #: src/bookmark.py:230
@@ -180,7 +180,7 @@ msgstr "Nome"
 
 #: src/bookmark.py:257
 msgid "Page"
-msgstr "Páxina"
+msgstr "Pï¿½xina"
 
 #: src/comment.py:16 src/preferences.py:299
 msgid "Comments"
@@ -188,12 +188,12 @@ msgstr "Comentarios"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Non foi posíbel ler %s"
+msgid "Could not read {}"
+msgstr "Non foi posï¿½bel ler {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
-msgstr "Hai algúns arquivos obsoletos no seu ordenador."
+msgstr "Hai algï¿½ns arquivos obsoletos no seu ordenador."
 
 #: src/deprecated.py:22
 msgid ""
@@ -203,9 +203,9 @@ msgid ""
 "remove these files in order to save some disk space. Do you want these files "
 "to be removed for you now?"
 msgstr ""
-"Algúns arquivos obsoletos (usados para gardar as preferencias, a "
-"biblioteca, os favoritos e outros, en versións antigas do Comix) foron "
-"encontrados no seu ordenador. Se vostede non ten pensado usar as versións antigas "
+"Algï¿½ns arquivos obsoletos (usados para gardar as preferencias, a "
+"biblioteca, os favoritos e outros, en versiï¿½ns antigas do Comix) foron "
+"encontrados no seu ordenador. Se vostede non ten pensado usar as versiï¿½ns antigas "
 "do Comix novamente, debe eliminar eses arquivos para economizar espazo "
 "no disco duro. Desexa que eses arquivos sexan eliminados agora?"
 
@@ -246,12 +246,12 @@ msgid ""
 "Please note that the only files that are automatically added to this list "
 "are those files in archives that Comix recognizes as comments."
 msgstr ""
-"Por favor, teña en conta que os únicos arquivos engadidos automaticamente a esta "
-"lista son os arquivos que o Comix recoñece como comentarios."
+"Por favor, teï¿½a en conta que os ï¿½nicos arquivos engadidos automaticamente a esta "
+"lista son os arquivos que o Comix recoï¿½ece como comentarios."
 
 #: src/edit.py:273
 msgid "Size"
-msgstr "Tamaño"
+msgstr "Tamaï¿½o"
 
 #: src/enhance.py:51
 msgid "Enhance image"
@@ -271,7 +271,7 @@ msgstr "Contraste"
 
 #: src/enhance.py:101
 msgid "Saturation"
-msgstr "Saturación"
+msgstr "Saturaciï¿½n"
 
 #: src/enhance.py:112
 msgid "Sharpness"
@@ -319,12 +319,12 @@ msgstr "Arquivos tar"
 
 #: src/filechooser.py:134
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Un arquivo co nome '%s' xa existe. Desexa substituílo?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Un arquivo co nome '{}' xa existe. Desexa substituï¿½lo?"
 
 #: src/filechooser.py:137
 msgid "Replacing it will overwrite its contents."
-msgstr "A substitución sobreescribirá o seu contido."
+msgstr "A substituciï¿½n sobreescribirï¿½ o seu contido."
 
 #: src/filechooser.py:182 src/filechooser.py:260
 msgid "All images"
@@ -340,36 +340,36 @@ msgstr "Imaxes PNG"
 
 #: src/filechooser.py:206
 msgid "Automatically add the books to this collection"
-msgstr "Engadir libros a esta colección automaticamente"
+msgstr "Engadir libros a esta colecciï¿½n automaticamente"
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Imposíbel abrir %s: É un directorio."
+msgid "Could not open {}: Is a directory."
+msgstr "Imposï¿½bel abrir {}: ï¿½ un directorio."
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Imposíbel abrir %s: O arquivo non existe."
+msgid "Could not open {}: No such file."
+msgstr "Imposï¿½bel abrir {}: O arquivo non existe."
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Imposíbel abrir %s: Permiso denegado."
+msgid "Could not open {}: Permission denied."
+msgstr "Imposï¿½bel abrir {}: Permiso denegado."
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Imposíbel abrir %s: Tipo de arquivo descoñecido."
+msgid "Could not open {}: Unknown file type."
+msgstr "Imposï¿½bel abrir {}: Tipo de arquivo descoï¿½ecido."
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Non hai imaxes en '%s'"
+msgid "No images in '{}'"
+msgstr "Non hai imaxes en '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
-msgstr "Tipo de arquivo descoñecido"
+msgstr "Tipo de arquivo descoï¿½ecido"
 
 #: src/librarybackend.py:273 src/librarybackend.py:275
 msgid "(Copy)"
@@ -385,11 +385,11 @@ msgstr "Renomear..."
 
 #: src/library.py:152
 msgid "Duplicate collection"
-msgstr "Colección duplicada"
+msgstr "Colecciï¿½n duplicada"
 
 #: src/library.py:154
 msgid "Remove collection..."
-msgstr "Remover coleção..."
+msgstr "Remover coleï¿½ï¿½o..."
 
 #: src/library.py:202
 msgid "All books"
@@ -397,64 +397,64 @@ msgstr "Todos os libros"
 
 #: src/library.py:231
 msgid "Remove collection from the library?"
-msgstr "Eliminar a colección da biblioteca?"
+msgstr "Eliminar a colecciï¿½n da biblioteca?"
 
 #: src/library.py:233
 msgid ""
 "The selected collection will be removed from the library (but the books and "
 "subcollections in it will remain). Are you sure that you want to continue?"
 msgstr ""
-"A colección seleccionada será eliminada da biblioteca (mais os libros e as sub-"
-"coleccións dentro dela permanecerán). Está seguro de que desexa continuar?"
+"A colecciï¿½n seleccionada serï¿½ eliminada da biblioteca (mais os libros e as sub-"
+"colecciï¿½ns dentro dela permanecerï¿½n). Estï¿½ seguro de que desexa continuar?"
 
 #: src/library.py:251
 msgid "Rename collection?"
-msgstr "Renomear a colección?"
+msgstr "Renomear a colecciï¿½n?"
 
 #: src/library.py:253
 msgid "Please enter a new name for the selected collection."
-msgstr "Por favor, introduza un novo nome para a colección seleccionada."
+msgstr "Por favor, introduza un novo nome para a colecciï¿½n seleccionada."
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Imposíbel renomear como '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Imposï¿½bel renomear como '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
-msgstr "Unha colección con ese nome xa existe."
+msgstr "Unha colecciï¿½n con ese nome xa existe."
 
 #: src/library.py:285
 msgid "Could not duplicate collection."
-msgstr "Imposíbel duplicar a colección."
+msgstr "Imposï¿½bel duplicar a colecciï¿½n."
 
 #: src/library.py:382
 msgid "Root"
-msgstr "Raíz"
+msgstr "Raï¿½z"
 
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Coloque a colección '%(subcollection)s' na colección '%(supercollection)s'."
+"Coloque a colecciï¿½n '{subcollection}' na colecciï¿½n '{supercollection}'."
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Engadir libros a '%s'."
+msgid "Add books to '{}'."
+msgstr "Engadir libros a '{}'."
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Mover libros de '%(source collection)s' a '%(destination collection)s'."
+"Mover libros de '{source collection}' a '{destination collection}'."
 
 #: src/library.py:493
 msgid "Remove from this collection"
-msgstr "Eliminar desta colección"
+msgstr "Eliminar desta colecciï¿½n"
 
 #: src/library.py:496
 msgid "Remove from the library..."
@@ -462,8 +462,8 @@ msgstr "Eliminar da biblioteca..."
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Foron eliminados %(num)d libro(s) de '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Foron eliminados {num} libro(s) de '{collection}'."
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -474,13 +474,13 @@ msgid ""
 "The selected books will be removed from the library (but the original files "
 "will be untouched). Are you sure that you want to continue?"
 msgstr ""
-"Os libros seleccionados serán eliminados da biblioteca (mais os arquivos "
-"orixinais non serán modificados). Está seguro de que desexa continuar?"
+"Os libros seleccionados serï¿½n eliminados da biblioteca (mais os arquivos "
+"orixinais non serï¿½n modificados). Estï¿½ seguro de que desexa continuar?"
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Foron eliminados %d libro(s) da biblioteca."
+msgid "Removed {} book(s) from the library."
+msgstr "Foron eliminados {} libro(s) da biblioteca."
 
 #: src/library.py:770
 msgid "Search"
@@ -491,12 +491,12 @@ msgid ""
 "Display only those books that have the specified text string in their full "
 "path. The search is not case sensitive."
 msgstr ""
-"Mostrar só os libros que teñan o texto especificado no seu roteiro completo. A "
-"busca non diferencia entre letras maiúsculas e minúsculas."
+"Mostrar sï¿½ os libros que teï¿½an o texto especificado no seu roteiro completo. A "
+"busca non diferencia entre letras maiï¿½sculas e minï¿½sculas."
 
 #: src/library.py:777
 msgid "Cover size"
-msgstr "Tamanño da portada"
+msgstr "Tamanï¿½o da portada"
 
 #: src/library.py:790
 msgid "Add books"
@@ -504,15 +504,15 @@ msgstr "Engadir libros"
 
 #: src/library.py:794
 msgid "Add more books to the library."
-msgstr "Engadir máis libros á biblioteca."
+msgstr "Engadir mï¿½is libros ï¿½ biblioteca."
 
 #: src/library.py:796
 msgid "Add collection"
-msgstr "Engadir colección"
+msgstr "Engadir colecciï¿½n"
 
 #: src/library.py:801
 msgid "Add a new empty collection."
-msgstr "Engadir nova colección baleira."
+msgstr "Engadir nova colecciï¿½n baleira."
 
 #: src/library.py:807
 msgid "Open the selected book."
@@ -520,25 +520,25 @@ msgstr "Abrir o libro seleccionado."
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d páxinas"
+msgid "{} pages"
+msgstr "{} pï¿½xinas"
 
 #: src/library.py:855
 msgid "Add new collection?"
-msgstr "Engadir nova colección?"
+msgstr "Engadir nova colecciï¿½n?"
 
 #: src/library.py:857
 msgid "Please enter a name for the new collection."
-msgstr "Por favor, introduza o nome da nova colección."
+msgstr "Por favor, introduza o nome da nova colecciï¿½n."
 
 #: src/library.py:863
 msgid "New collection"
-msgstr "Nova colección"
+msgstr "Nova colecciï¿½n"
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Imposíbel engadir unha nova colección chamada '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Imposï¿½bel engadir unha nova colecciï¿½n chamada '{}'."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -550,12 +550,12 @@ msgstr "Libros engadidos"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Engadindo '%s'..."
+msgid "Adding '{}'..."
+msgstr "Engadindo '{}'..."
 
 #: src/main.py:699
 msgid "SLIDESHOW"
-msgstr "Presentación de imaxes"
+msgstr "Presentaciï¿½n de imaxes"
 
 #: src/preferences.py:80
 msgid "Preferences"
@@ -575,12 +575,12 @@ msgstr "Sempre usar esa cor como cor de fondo."
 
 #: src/preferences.py:104
 msgid "Use dynamic background colour."
-msgstr "Usar cor de fondo dinámica."
+msgstr "Usar cor de fondo dinï¿½mica."
 
 #: src/preferences.py:108
 msgid "Automatically pick a background colour that fits the viewed image."
 msgstr ""
-"Escoller unha cor de fondo compatíbel coa imaxe visualizada "
+"Escoller unha cor de fondo compatï¿½bel coa imaxe visualizada "
 "automaticamente."
 
 #: src/preferences.py:111
@@ -589,11 +589,11 @@ msgstr "Miniaturas"
 
 #: src/preferences.py:112
 msgid "Thumbnail size (in pixels)"
-msgstr "Tamaño da miniatura (en pixels)"
+msgstr "Tamaï¿½o da miniatura (en pixels)"
 
 #: src/preferences.py:119
 msgid "Show page numbers on thumbnails."
-msgstr "Mostrar números de páxina nas miniaturas."
+msgstr "Mostrar nï¿½meros de pï¿½xina nas miniaturas."
 
 #: src/preferences.py:126
 msgid "Magnifying Glass"
@@ -601,14 +601,14 @@ msgstr "Lente de aumento"
 
 #: src/preferences.py:127
 msgid "Magnifying glass size (in pixels)"
-msgstr "Tamaño da lente de aumento (en pixels)"
+msgstr "Tamaï¿½o da lente de aumento (en pixels)"
 
 #: src/preferences.py:133
 msgid ""
 "Set the size of the magnifying glass. It is a square with a side of this "
 "many pixels."
 msgstr ""
-"Axustar o tamaño da lente de aumento. É un cadrado con ese tamaño de "
+"Axustar o tamaï¿½o da lente de aumento. ï¿½ un cadrado con ese tamaï¿½o de "
 "pixels."
 
 #: src/preferences.py:135
@@ -633,9 +633,9 @@ msgid ""
 "current zoom mode requests it. If this preference is unset, images are never "
 "scaled to be larger than their original size."
 msgstr ""
-"Estricar imaxes para un tamaño que é maior que o seu tamaño original se o "
-"modo de zoom actual o esixe. Se esta preferencia non está marcada, as "
-"imaxes nunca serán vistas nun tamaño maior que o orixinal."
+"Estricar imaxes para un tamaï¿½o que ï¿½ maior que o seu tamaï¿½o original se o "
+"modo de zoom actual o esixe. Se esta preferencia non estï¿½ marcada, as "
+"imaxes nunca serï¿½n vistas nun tamaï¿½o maior que o orixinal."
 
 #: src/preferences.py:153
 msgid "Transparency"
@@ -651,7 +651,7 @@ msgid ""
 "is unset, the background is plain white instead."
 msgstr ""
 "Usar un fondo cuadriculado cinza para as imaxes transparentes. Se esta "
-"preferencia non estiver marcada, o fondo usado será branco."
+"preferencia non estiver marcada, o fondo usado serï¿½ branco."
 
 #: src/preferences.py:163
 msgid "Appearance"
@@ -659,11 +659,11 @@ msgstr "Aparencia"
 
 #: src/preferences.py:169
 msgid "Scroll"
-msgstr "Progresión das imaxes"
+msgstr "Progresiï¿½n das imaxes"
 
 #: src/preferences.py:171
 msgid "Use smart space key scrolling."
-msgstr "Usar a progresión intelixente de imaxes coa tecla de espazo."
+msgstr "Usar a progresiï¿½n intelixente de imaxes coa tecla de espazo."
 
 #: src/preferences.py:176
 msgid ""
@@ -672,14 +672,14 @@ msgid ""
 "also scrolls sideways and so tries to follow the natural reading order of "
 "the comic book."
 msgstr ""
-"Usar a progresión intelixente de imaxes coa tecla de espazo. Normalmente, a tecla de espazo "
-"só avanza para abaixo (ou para arriba, cando se apreta a tecla de maiúsculas). No entanto, con "
-"esta preferencia tamén avanzará para os lados e tentará seguir a orde natural de "
-"lectura dunha banda deseñada."
+"Usar a progresiï¿½n intelixente de imaxes coa tecla de espazo. Normalmente, a tecla de espazo "
+"sï¿½ avanza para abaixo (ou para arriba, cando se apreta a tecla de maiï¿½sculas). No entanto, con "
+"esta preferencia tamï¿½n avanzarï¿½ para os lados e tentarï¿½ seguir a orde natural de "
+"lectura dunha banda deseï¿½ada."
 
 #: src/preferences.py:180
 msgid "Flip pages when scrolling off the edges of the page."
-msgstr "Pasar as páxinas cando se avance fóra do bordo da páxina."
+msgstr "Pasar as pï¿½xinas cando se avance fï¿½ra do bordo da pï¿½xina."
 
 #: src/preferences.py:185
 msgid ""
@@ -687,28 +687,28 @@ msgid ""
 "arrow keys. It takes three consecutive \"steps\" with the scroll wheel or "
 "the arrow keys for the pages to be flipped."
 msgstr ""
-"Pasar as páxinas cando cando se avance \"fóra da páxina\" coa roda do rato "
-"ou coas teclas do cursor. Serán necesarios tres \"pasos\" consecutivos coa roda "
-"do rato ou coas teclas do cursor para pasar as páxinas."
+"Pasar as pï¿½xinas cando cando se avance \"fï¿½ra da pï¿½xina\" coa roda do rato "
+"ou coas teclas do cursor. Serï¿½n necesarios tres \"pasos\" consecutivos coa roda "
+"do rato ou coas teclas do cursor para pasar as pï¿½xinas."
 
 #: src/preferences.py:188 src/ui.py:298
 msgid "Double page mode"
-msgstr "Modo de páxina dobre"
+msgstr "Modo de pï¿½xina dobre"
 
 #: src/preferences.py:190
 msgid "Flip two pages in double page mode."
-msgstr "Pasar dúas páxinas no modo de páxina dobre."
+msgstr "Pasar dï¿½as pï¿½xinas no modo de pï¿½xina dobre."
 
 #: src/preferences.py:195
 msgid ""
 "Flip two pages, instead of one, each time we flip pages in double page mode."
 msgstr ""
-"Pasar dúas páxinas, en lugar dunha, cada vez que se pase páxina no modo de "
-"páxina dobre."
+"Pasar dï¿½as pï¿½xinas, en lugar dunha, cada vez que se pase pï¿½xina no modo de "
+"pï¿½xina dobre."
 
 #: src/preferences.py:198
 msgid "Show only one wide image in double page mode."
-msgstr "Mostrar só unha imaxe larga no modo de páxina dobre"
+msgstr "Mostrar sï¿½ unha imaxe larga no modo de pï¿½xina dobre"
 
 #: src/preferences.py:204
 msgid ""
@@ -716,9 +716,9 @@ msgid ""
 "height. The result of this is that scans that span two pages are displayed "
 "properly (i.e. alone) also in double page mode."
 msgstr ""
-"Mostra só unha imaxe no modo de páxina dobre, se a largura da imaxe excede "
-"da súa altura. O resultado disto é que as imaxes escaneadas que abranguen dúas páxinas serán "
-"mostrados adecuadamente (isto é, de maneira illada) tamén no modo de páxina dobre."
+"Mostra sï¿½ unha imaxe no modo de pï¿½xina dobre, se a largura da imaxe excede "
+"da sï¿½a altura. O resultado disto ï¿½ que as imaxes escaneadas que abranguen dï¿½as pï¿½xinas serï¿½n "
+"mostrados adecuadamente (isto ï¿½, de maneira illada) tamï¿½n no modo de pï¿½xina dobre."
 
 #: src/preferences.py:207
 msgid "Files"
@@ -726,19 +726,19 @@ msgstr "Arquivos"
 
 #: src/preferences.py:209
 msgid "Automatically open the next archive."
-msgstr "Abrir o próximo arquivo automaticamente."
+msgstr "Abrir o prï¿½ximo arquivo automaticamente."
 
 #: src/preferences.py:214
 msgid ""
 "Automatically open the next archive in the directory when flipping past the "
 "last page, or the previous archive when flipping past the first page."
 msgstr ""
-"Abre o próximo arquivo do directorio automaticamente cando se pase a "
-"derradeira páxina, ou o arquivo anterior cando se pase atrás antes da primeira páxina."
+"Abre o prï¿½ximo arquivo do directorio automaticamente cando se pase a "
+"derradeira pï¿½xina, ou o arquivo anterior cando se pase atrï¿½s antes da primeira pï¿½xina."
 
 #: src/preferences.py:217
 msgid "Automatically open the last viewed file on startup."
-msgstr "Abrir o último arquivo visto automaticamente ao iniciar."
+msgstr "Abrir o ï¿½ltimo arquivo visto automaticamente ao iniciar."
 
 #: src/preferences.py:222
 msgid ""
@@ -746,18 +746,18 @@ msgid ""
 "closed."
 msgstr ""
 "Abre, cando se inicia, o arquivo que estaba aberto cando o Comix foi fechado "
-"por última vez."
+"por ï¿½ltima vez."
 
 #: src/preferences.py:225
 msgid "Store information about recently opened files."
-msgstr "Garda informacións sobre arquivos abertos recentemente."
+msgstr "Garda informaciï¿½ns sobre arquivos abertos recentemente."
 
 #: src/preferences.py:230
 msgid ""
 "Add information about all files opened from within Comix to the shared "
 "recent files list."
 msgstr ""
-"Engadir informacións sobre todos os arquivos abertos dentro do Comix para a "
+"Engadir informaciï¿½ns sobre todos os arquivos abertos dentro do Comix para a "
 "lista de arquivos compartidos recentemente."
 
 #: src/preferences.py:233
@@ -770,17 +770,17 @@ msgid ""
 "specification. These thumbnails are shared by many other applications, such "
 "as most file managers."
 msgstr ""
-"Garda as miniaturas de arquivos abertos de acordo coa especificación do "
+"Garda as miniaturas de arquivos abertos de acordo coa especificaciï¿½n do "
 "freedesktop.org. Esas miniaturas son compartidas por varios outros "
 "programas, como a maior parte dos xestores de arquivos."
 
 #: src/preferences.py:241
 msgid "Cache"
-msgstr "Caché"
+msgstr "Cachï¿½"
 
 #: src/preferences.py:242
 msgid "Use a cache to speed up browsing."
-msgstr "Usar un caché para aumentar a velocidade de navegación."
+msgstr "Usar un cachï¿½ para aumentar a velocidade de navegaciï¿½n."
 
 #: src/preferences.py:246
 msgid ""
@@ -789,9 +789,9 @@ msgid ""
 "recommended that you have this preference set, unless you are running short "
 "on free RAM."
 msgstr ""
-"Fai un caché da imaxes próximas a imaxe vista actualmente para "
-"acelerar a navegación. Xa que a mellora de velocidade é grande, é "
-"recomendábel ter esta preferencia marcada, agás que vostede dispoña de pouca "
+"Fai un cachï¿½ da imaxes prï¿½ximas a imaxe vista actualmente para "
+"acelerar a navegaciï¿½n. Xa que a mellora de velocidade ï¿½ grande, ï¿½ "
+"recomendï¿½bel ter esta preferencia marcada, agï¿½s que vostede dispoï¿½a de pouca "
 "memoria RAM no seu ordenador."
 
 #: src/preferences.py:248
@@ -804,7 +804,7 @@ msgstr "Preferencias por defecto"
 
 #: src/preferences.py:256
 msgid "Use double page mode by default."
-msgstr "Usar o modo de páxina dobre por defecto."
+msgstr "Usar o modo de pï¿½xina dobre por defecto."
 
 #: src/preferences.py:261
 msgid "Use fullscreen by default."
@@ -820,7 +820,7 @@ msgstr "Modo de zoom por defecto"
 
 #: src/preferences.py:273 src/ui.py:290
 msgid "Best fit mode"
-msgstr "Modo de encaixe óptimo"
+msgstr "Modo de encaixe ï¿½ptimo"
 
 #: src/preferences.py:274 src/ui.py:292
 msgid "Fit width mode"
@@ -844,27 +844,27 @@ msgstr "Esconder todas as barras de ferramentas por defecto no modo de pantalla 
 
 #: src/preferences.py:290
 msgid "Slideshow"
-msgstr "Presentación de imaxes"
+msgstr "Presentaciï¿½n de imaxes"
 
 #: src/preferences.py:291
 msgid "Slideshow delay (in seconds)"
-msgstr "Espera da presentación de imaxes (en segundos)"
+msgstr "Espera da presentaciï¿½n de imaxes (en segundos)"
 
 #: src/preferences.py:300
 msgid "Comment extensions"
-msgstr "Comentar as extensións"
+msgstr "Comentar as extensiï¿½ns"
 
 #: src/preferences.py:306
 msgid ""
 "Treat all files found within archives, that have one of these file endings, "
 "as comments."
 msgstr ""
-"Tratar todos os documentos atopados dentro de arquivos, incluíndo os que teñen "
-"estas terminacións de arquivo, como comentarios."
+"Tratar todos os documentos atopados dentro de arquivos, incluï¿½ndo os que teï¿½en "
+"estas terminaciï¿½ns de arquivo, como comentarios."
 
 #: src/preferences.py:309
 msgid "Rotation"
-msgstr "Rotación"
+msgstr "Rotaciï¿½n"
 
 #: src/preferences.py:311
 msgid "Automatically rotate images according to their metadata."
@@ -874,12 +874,12 @@ msgstr "Rotar automaticamente as imaxes segundo os seus metadatos"
 msgid ""
 "Automatically rotate images when an orientation is specified in the image "
 "metadata, such as in an Exif tag."
-msgstr "Rotar automaticamente as imaxes cando a orientación se especifique "
+msgstr "Rotar automaticamente as imaxes cando a orientaciï¿½n se especifique "
 "nos metadatos, como no caso dos tag Exif."
 
 #: src/preferences.py:318
 msgid "Display"
-msgstr "Superficie de visualización"
+msgstr "Superficie de visualizaciï¿½n"
 
 #: src/properties.py:94
 msgid "Properties"
@@ -887,8 +887,8 @@ msgstr "Propiedades"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d comentarios"
+msgid "{} comments"
+msgstr "{} comentarios"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -920,7 +920,7 @@ msgstr "Imaxe"
 
 #: src/thumbremover.py:24
 msgid "Thumbnail maintenance"
-msgstr "Manutención de miniaturas"
+msgstr "Manutenciï¿½n de miniaturas"
 
 #: src/thumbremover.py:26
 msgid "Cleanup"
@@ -938,11 +938,11 @@ msgid ""
 "files have been removed - wasting space. This dialog can cleanup your stored "
 "thumbnails by removing orphaned and outdated thumbnails."
 msgstr ""
-"As miniaturas para os arquivos (como arquivos de imaxes e bandas deseñadas "
-"serán gardadas no seu directorio de usuario. Moitos programas "
+"As miniaturas para os arquivos (como arquivos de imaxes e bandas deseï¿½adas "
+"serï¿½n gardadas no seu directorio de usuario. Moitos programas "
 "diferentes usan e crean esas miniaturas, mais algunhas veces as miniaturas "
 "permanecen cando os arquivos orixinais son eliminados - "
-"desperdiciando espazo. Este diálogo pode limpar as miniaturas ao eliminar "
+"desperdiciando espazo. Este diï¿½logo pode limpar as miniaturas ao eliminar "
 "minaturas orfas e obsoletas."
 
 #: src/thumbremover.py:60
@@ -951,7 +951,7 @@ msgstr "Directorio de miniaturas"
 
 #: src/thumbremover.py:67
 msgid "Total number of thumbnails"
-msgstr "Número total de miniaturas"
+msgstr "Nï¿½mero total de miniaturas"
 
 #: src/thumbremover.py:70 src/thumbremover.py:77
 msgid "Calculating..."
@@ -959,7 +959,7 @@ msgstr "Calculando..."
 
 #: src/thumbremover.py:74
 msgid "Total size of thumbnails"
-msgstr "Tamaño total das miniaturas"
+msgstr "Tamaï¿½o total das miniaturas"
 
 #: src/thumbremover.py:82
 msgid "Do you want to cleanup orphaned and outdated thumbnails now?"
@@ -971,32 +971,32 @@ msgstr "Eliminando miniaturas"
 
 #: src/thumbremover.py:137
 msgid "Number of removed thumbnails"
-msgstr "Número de miniaturas eliminadas"
+msgstr "Nï¿½mero de miniaturas eliminadas"
 
 #: src/thumbremover.py:144
 msgid "Total size of removed thumbnails"
-msgstr "Tamaño total das miniaturas eliminadas"
+msgstr "Tamaï¿½o total das miniaturas eliminadas"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Eliminada a miniatura de '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Eliminada a miniatura de '{}'"
 
 #: src/ui.py:34
 msgid "_Next page"
-msgstr "_Próxima páxina"
+msgstr "_Prï¿½xima pï¿½xina"
 
 #: src/ui.py:36
 msgid "_Previous page"
-msgstr "Pá_xina anterior"
+msgstr "Pï¿½_xina anterior"
 
 #: src/ui.py:38
 msgid "_First page"
-msgstr "P_rimeira páxina"
+msgstr "P_rimeira pï¿½xina"
 
 #: src/ui.py:40
 msgid "_Last page"
-msgstr "_Ultima páxina"
+msgstr "_Ultima pï¿½xina"
 
 #: src/ui.py:42
 msgid "_Zoom in"
@@ -1008,7 +1008,7 @@ msgstr "_Diminuir zoom"
 
 #: src/ui.py:46
 msgid "O_riginal size"
-msgstr "Tamaño _orixinal"
+msgstr "Tamaï¿½o _orixinal"
 
 #: src/ui.py:48
 msgid "_Close"
@@ -1016,19 +1016,19 @@ msgstr "_Fechar"
 
 #: src/ui.py:50
 msgid "_Quit"
-msgstr "_Saír"
+msgstr "_Saï¿½r"
 
 #: src/ui.py:52
 msgid "_Rotate 90 degrees CW"
-msgstr "Ro_tación de 90 graos horarios"
+msgstr "Ro_taciï¿½n de 90 graos horarios"
 
 #: src/ui.py:54
 msgid "Rotate 180 de_grees"
-msgstr "Rotación de 180 graos horarios"
+msgstr "Rotaciï¿½n de 180 graos horarios"
 
 #: src/ui.py:56
 msgid "Rotat_e 90 degrees CCW"
-msgstr "Ro_tación de 90 graos antihorarios"
+msgstr "Ro_taciï¿½n de 90 graos antihorarios"
 
 #: src/ui.py:58
 msgid "Fli_p horizontally"
@@ -1084,7 +1084,7 @@ msgstr "_Pantalla completa"
 
 #: src/ui.py:77
 msgid "_Double page mode"
-msgstr "Modo de páxina _dobre"
+msgstr "Modo de pï¿½xina _dobre"
 
 #: src/ui.py:79
 msgid "_Toolbar"
@@ -1116,11 +1116,11 @@ msgstr "_Modo manga"
 
 #: src/ui.py:93
 msgid "_Keep transformation"
-msgstr "_Manter a transformación"
+msgstr "_Manter a transformaciï¿½n"
 
 #: src/ui.py:95
 msgid "Run _slideshow"
-msgstr "Come_zar a presentación de imaxes"
+msgstr "Come_zar a presentaciï¿½n de imaxes"
 
 #: src/ui.py:97
 msgid "Magnifying _glass"
@@ -1128,7 +1128,7 @@ msgstr "_Lente de aumento"
 
 #: src/ui.py:103
 msgid "_Best fit mode"
-msgstr "Modo de axuste ó_ptimo"
+msgstr "Modo de axuste ï¿½_ptimo"
 
 #: src/ui.py:105
 msgid "Fit _width mode"
@@ -1168,7 +1168,7 @@ msgstr "_Mellorar imaxe..."
 
 #: src/ui.py:128
 msgid "_Thumbnail maintenance..."
-msgstr "Manu_tención de miniaturas..."
+msgstr "Manu_tenciï¿½n de miniaturas..."
 
 #: src/ui.py:130
 msgid "Pr_eferences"
@@ -1180,19 +1180,19 @@ msgstr "Bib_lioteca..."
 
 #: src/ui.py:284
 msgid "First page"
-msgstr "Primeira páxina"
+msgstr "Primeira pï¿½xina"
 
 #: src/ui.py:286
 msgid "Previous page"
-msgstr "Páxina anterior"
+msgstr "Pï¿½xina anterior"
 
 #: src/ui.py:287
 msgid "Next page"
-msgstr "Próxima páxina"
+msgstr "Prï¿½xima pï¿½xina"
 
 #: src/ui.py:288
 msgid "Last page"
-msgstr "Última páxina"
+msgstr "ï¿½ltima pï¿½xina"
 
 #: src/ui.py:299
 msgid "Manga mode"

--- a/messages/gl/LC_MESSAGES/comix.po
+++ b/messages/gl/LC_MESSAGES/comix.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: Marcelo G�es <vanquirius@gentoo.org>\n"
+"Last-Translator: Marcelo Góes <vanquirius@gentoo.org>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
@@ -16,16 +16,16 @@ msgstr "Sobre"
 #: src/about.py:56
 msgid "Comix is an image viewer specifically designed to handle comic books."
 msgstr ""
-"Comix � un visualizador de imaxes dese�ado especificamente para ler "
-"bandas dese�adas no seu ordenador."
+"Comix é un visualizador de imaxes deseñado especificamente para ler "
+"bandas deseñadas no seu ordenador."
 
 #: src/about.py:58
 msgid "It reads ZIP, RAR and tar archives, as well as plain image files."
-msgstr "Le arquivos ZIP, RAR e tar, as� como imaxes normais."
+msgstr "Le arquivos ZIP, RAR e tar, así como imaxes normais."
 
 #: src/about.py:60
 msgid "Comix is licensed under the GNU General Public License."
-msgstr "Comix publ�case baixo a GNU General Public License."
+msgstr "Comix publícase baixo a GNU General Public License."
 
 #: src/about.py:83
 msgid "Developer"
@@ -33,91 +33,91 @@ msgstr "Programador"
 
 #: src/about.py:84 src/about.py:85
 msgid "Simplified Chinese translation"
-msgstr "Traduci�n ao chin�s simplificado"
+msgstr "Tradución ao chinés simplificado"
 
 #: src/about.py:86
 msgid "Spanish translation"
-msgstr "Traduci�n ao castel�n"
+msgstr "Tradución ao castelán"
 
 #: src/about.py:87
 msgid "Brazilian Portuguese translation"
-msgstr "Traduci�n ao portugu�s do Brasil"
+msgstr "Tradución ao portugués do Brasil"
 
 #: src/about.py:88
 msgid "German translation and Nautilus thumbnailer"
-msgstr "Traduci�n ao alem�n e thumbnailer do Nautilus"
+msgstr "Tradución ao alemán e thumbnailer do Nautilus"
 
 #: src/about.py:89 src/about.py:90
 msgid "Italian translation"
-msgstr "Traduci�n ao italiano"
+msgstr "Tradución ao italiano"
 
 #: src/about.py:91
 msgid "Dutch translation"
-msgstr "Traduci�n ao holand�s"
+msgstr "Tradución ao holandés"
 
 #: src/about.py:92
 msgid "French translation"
-msgstr "Traduci�n ao franc�s"
+msgstr "Tradución ao francés"
 
 #: src/about.py:93 src/about.py:94
 msgid "Polish translation"
-msgstr "Traduci�n ao polaco"
+msgstr "Tradución ao polaco"
 
 #: src/about.py:95
 msgid "Greek translation"
-msgstr "Traduci�n ao grego"
+msgstr "Tradución ao grego"
 
 #: src/about.py:96
 msgid "Catalan translation"
-msgstr "Traduci�n ao catal�n"
+msgstr "Tradución ao catalán"
 
 #: src/about.py:97 src/about.py:98
 msgid "Traditional Chinese translation"
-msgstr "Traduci�n ao chin�s tradicional"
+msgstr "Tradución ao chinés tradicional"
 
 #: src/about.py:99
 msgid "Japanese translation"
-msgstr "Traduci�n ao xapon�s"
+msgstr "Tradución ao xaponés"
 
 #: src/about.py:100
 msgid "Hungarian translation"
-msgstr "Traduci�n ao h�ngaro"
+msgstr "Tradución ao húngaro"
 
 #: src/about.py:101
 msgid "Russian translation"
-msgstr "Traduci�n ao ruso"
+msgstr "Tradución ao ruso"
 
 #: src/about.py:102
 msgid "Croatian translation"
-msgstr "Traduci�n ao croata"
+msgstr "Tradución ao croata"
 
 #: src/about.py:103
 msgid "Korean translation"
-msgstr "Traduci�n ao coreano"
+msgstr "Tradución ao coreano"
 
 #: src/about.py:104
 msgid "Persian translation"
-msgstr "Traduci�n ao persa"
+msgstr "Tradución ao persa"
 
 #: src/about.py:105
 msgid "Indonesian translation"
-msgstr "Traduci�n ao indonesio"
+msgstr "Tradución ao indonesio"
 
 #: src/about.py:106
 msgid "Czech translation"
-msgstr "Traduci�n ao checo"
+msgstr "Tradución ao checo"
 
 #: src/about.py:107
 msgid "Icon design"
-msgstr "Dese�o das iconas"
+msgstr "Deseño das iconas"
 
 #: src/about.py:114
 msgid "Credits"
-msgstr "Cr�ditos"
+msgstr "Créditos"
 
 #: src/archive.py:66
 msgid "Could not find RAR file extractor!"
-msgstr "Non foi pos�bel encontrar un programa para a extracci�n de arquivos RAR!"
+msgstr "Non foi posíbel encontrar un programa para a extracción de arquivos RAR!"
 
 #: src/archive.py:68
 msgid ""
@@ -167,7 +167,7 @@ msgstr "Eliminar todos os favoritos?"
 msgid ""
 "All stored bookmarks will be removed. Are you sure that you want to continue?"
 msgstr ""
-"Todos os favoritos gravados ser�n eliminados. Est� seguro de que desexa "
+"Todos os favoritos gravados serán eliminados. Está seguro de que desexa "
 "continuar?"
 
 #: src/bookmark.py:230
@@ -180,7 +180,7 @@ msgstr "Nome"
 
 #: src/bookmark.py:257
 msgid "Page"
-msgstr "P�xina"
+msgstr "Páxina"
 
 #: src/comment.py:16 src/preferences.py:299
 msgid "Comments"
@@ -189,11 +189,11 @@ msgstr "Comentarios"
 #: src/comment.py:53
 #, python-format
 msgid "Could not read {}"
-msgstr "Non foi pos�bel ler {}"
+msgstr "Non foi posíbel ler {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
-msgstr "Hai alg�ns arquivos obsoletos no seu ordenador."
+msgstr "Hai algúns arquivos obsoletos no seu ordenador."
 
 #: src/deprecated.py:22
 msgid ""
@@ -203,9 +203,9 @@ msgid ""
 "remove these files in order to save some disk space. Do you want these files "
 "to be removed for you now?"
 msgstr ""
-"Alg�ns arquivos obsoletos (usados para gardar as preferencias, a "
-"biblioteca, os favoritos e outros, en versi�ns antigas do Comix) foron "
-"encontrados no seu ordenador. Se vostede non ten pensado usar as versi�ns antigas "
+"Algúns arquivos obsoletos (usados para gardar as preferencias, a "
+"biblioteca, os favoritos e outros, en versións antigas do Comix) foron "
+"encontrados no seu ordenador. Se vostede non ten pensado usar as versións antigas "
 "do Comix novamente, debe eliminar eses arquivos para economizar espazo "
 "no disco duro. Desexa que eses arquivos sexan eliminados agora?"
 
@@ -246,12 +246,12 @@ msgid ""
 "Please note that the only files that are automatically added to this list "
 "are those files in archives that Comix recognizes as comments."
 msgstr ""
-"Por favor, te�a en conta que os �nicos arquivos engadidos automaticamente a esta "
-"lista son os arquivos que o Comix reco�ece como comentarios."
+"Por favor, teña en conta que os únicos arquivos engadidos automaticamente a esta "
+"lista son os arquivos que o Comix recoñece como comentarios."
 
 #: src/edit.py:273
 msgid "Size"
-msgstr "Tama�o"
+msgstr "Tamaño"
 
 #: src/enhance.py:51
 msgid "Enhance image"
@@ -271,7 +271,7 @@ msgstr "Contraste"
 
 #: src/enhance.py:101
 msgid "Saturation"
-msgstr "Saturaci�n"
+msgstr "Saturación"
 
 #: src/enhance.py:112
 msgid "Sharpness"
@@ -320,11 +320,11 @@ msgstr "Arquivos tar"
 #: src/filechooser.py:134
 #, python-format
 msgid "A file named '{}' already exists. Do you want to replace it?"
-msgstr "Un arquivo co nome '{}' xa existe. Desexa substitu�lo?"
+msgstr "Un arquivo co nome '{}' xa existe. Desexa substituílo?"
 
 #: src/filechooser.py:137
 msgid "Replacing it will overwrite its contents."
-msgstr "A substituci�n sobreescribir� o seu contido."
+msgstr "A substitución sobreescribirá o seu contido."
 
 #: src/filechooser.py:182 src/filechooser.py:260
 msgid "All images"
@@ -340,27 +340,27 @@ msgstr "Imaxes PNG"
 
 #: src/filechooser.py:206
 msgid "Automatically add the books to this collection"
-msgstr "Engadir libros a esta colecci�n automaticamente"
+msgstr "Engadir libros a esta colección automaticamente"
 
 #: src/filehandler.py:209
 #, python-format
 msgid "Could not open {}: Is a directory."
-msgstr "Impos�bel abrir {}: � un directorio."
+msgstr "Imposíbel abrir {}: É un directorio."
 
 #: src/filehandler.py:213
 #, python-format
 msgid "Could not open {}: No such file."
-msgstr "Impos�bel abrir {}: O arquivo non existe."
+msgstr "Imposíbel abrir {}: O arquivo non existe."
 
 #: src/filehandler.py:217
 #, python-format
 msgid "Could not open {}: Permission denied."
-msgstr "Impos�bel abrir {}: Permiso denegado."
+msgstr "Imposíbel abrir {}: Permiso denegado."
 
 #: src/filehandler.py:222
 #, python-format
 msgid "Could not open {}: Unknown file type."
-msgstr "Impos�bel abrir {}: Tipo de arquivo desco�ecido."
+msgstr "Imposíbel abrir {}: Tipo de arquivo descoñecido."
 
 #: src/filehandler.py:285
 #, python-format
@@ -369,7 +369,7 @@ msgstr "Non hai imaxes en '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
-msgstr "Tipo de arquivo desco�ecido"
+msgstr "Tipo de arquivo descoñecido"
 
 #: src/librarybackend.py:273 src/librarybackend.py:275
 msgid "(Copy)"
@@ -385,11 +385,11 @@ msgstr "Renomear..."
 
 #: src/library.py:152
 msgid "Duplicate collection"
-msgstr "Colecci�n duplicada"
+msgstr "Colección duplicada"
 
 #: src/library.py:154
 msgid "Remove collection..."
-msgstr "Remover cole��o..."
+msgstr "Remover coleção..."
 
 #: src/library.py:202
 msgid "All books"
@@ -397,40 +397,40 @@ msgstr "Todos os libros"
 
 #: src/library.py:231
 msgid "Remove collection from the library?"
-msgstr "Eliminar a colecci�n da biblioteca?"
+msgstr "Eliminar a colección da biblioteca?"
 
 #: src/library.py:233
 msgid ""
 "The selected collection will be removed from the library (but the books and "
 "subcollections in it will remain). Are you sure that you want to continue?"
 msgstr ""
-"A colecci�n seleccionada ser� eliminada da biblioteca (mais os libros e as sub-"
-"colecci�ns dentro dela permanecer�n). Est� seguro de que desexa continuar?"
+"A colección seleccionada será eliminada da biblioteca (mais os libros e as sub-"
+"coleccións dentro dela permanecerán). Está seguro de que desexa continuar?"
 
 #: src/library.py:251
 msgid "Rename collection?"
-msgstr "Renomear a colecci�n?"
+msgstr "Renomear a colección?"
 
 #: src/library.py:253
 msgid "Please enter a new name for the selected collection."
-msgstr "Por favor, introduza un novo nome para a colecci�n seleccionada."
+msgstr "Por favor, introduza un novo nome para a colección seleccionada."
 
 #: src/library.py:271
 #, python-format
 msgid "Could not change the name to '{}'."
-msgstr "Impos�bel renomear como '{}'."
+msgstr "Imposíbel renomear como '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
-msgstr "Unha colecci�n con ese nome xa existe."
+msgstr "Unha colección con ese nome xa existe."
 
 #: src/library.py:285
 msgid "Could not duplicate collection."
-msgstr "Impos�bel duplicar a colecci�n."
+msgstr "Imposíbel duplicar a colección."
 
 #: src/library.py:382
 msgid "Root"
-msgstr "Ra�z"
+msgstr "Raíz"
 
 #: src/library.py:386
 #, python-format
@@ -438,7 +438,7 @@ msgid ""
 "Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Coloque a colecci�n '{subcollection}' na colecci�n '{supercollection}'."
+"Coloque a colección '{subcollection}' na colección '{supercollection}'."
 
 #: src/library.py:407
 #, python-format
@@ -454,7 +454,7 @@ msgstr ""
 
 #: src/library.py:493
 msgid "Remove from this collection"
-msgstr "Eliminar desta colecci�n"
+msgstr "Eliminar desta colección"
 
 #: src/library.py:496
 msgid "Remove from the library..."
@@ -474,8 +474,8 @@ msgid ""
 "The selected books will be removed from the library (but the original files "
 "will be untouched). Are you sure that you want to continue?"
 msgstr ""
-"Os libros seleccionados ser�n eliminados da biblioteca (mais os arquivos "
-"orixinais non ser�n modificados). Est� seguro de que desexa continuar?"
+"Os libros seleccionados serán eliminados da biblioteca (mais os arquivos "
+"orixinais non serán modificados). Está seguro de que desexa continuar?"
 
 #: src/library.py:610
 #, python-format
@@ -491,12 +491,12 @@ msgid ""
 "Display only those books that have the specified text string in their full "
 "path. The search is not case sensitive."
 msgstr ""
-"Mostrar s� os libros que te�an o texto especificado no seu roteiro completo. A "
-"busca non diferencia entre letras mai�sculas e min�sculas."
+"Mostrar só os libros que teñan o texto especificado no seu roteiro completo. A "
+"busca non diferencia entre letras maiúsculas e minúsculas."
 
 #: src/library.py:777
 msgid "Cover size"
-msgstr "Taman�o da portada"
+msgstr "Tamanño da portada"
 
 #: src/library.py:790
 msgid "Add books"
@@ -504,15 +504,15 @@ msgstr "Engadir libros"
 
 #: src/library.py:794
 msgid "Add more books to the library."
-msgstr "Engadir m�is libros � biblioteca."
+msgstr "Engadir máis libros á biblioteca."
 
 #: src/library.py:796
 msgid "Add collection"
-msgstr "Engadir colecci�n"
+msgstr "Engadir colección"
 
 #: src/library.py:801
 msgid "Add a new empty collection."
-msgstr "Engadir nova colecci�n baleira."
+msgstr "Engadir nova colección baleira."
 
 #: src/library.py:807
 msgid "Open the selected book."
@@ -521,24 +521,24 @@ msgstr "Abrir o libro seleccionado."
 #: src/library.py:833 src/properties.py:118
 #, python-format
 msgid "{} pages"
-msgstr "{} p�xinas"
+msgstr "{} páxinas"
 
 #: src/library.py:855
 msgid "Add new collection?"
-msgstr "Engadir nova colecci�n?"
+msgstr "Engadir nova colección?"
 
 #: src/library.py:857
 msgid "Please enter a name for the new collection."
-msgstr "Por favor, introduza o nome da nova colecci�n."
+msgstr "Por favor, introduza o nome da nova colección."
 
 #: src/library.py:863
 msgid "New collection"
-msgstr "Nova colecci�n"
+msgstr "Nova colección"
 
 #: src/library.py:877
 #, python-format
 msgid "Could not add a new collection called '{}'."
-msgstr "Impos�bel engadir unha nova colecci�n chamada '{}'."
+msgstr "Imposíbel engadir unha nova colección chamada '{}'."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -555,7 +555,7 @@ msgstr "Engadindo '{}'..."
 
 #: src/main.py:699
 msgid "SLIDESHOW"
-msgstr "Presentaci�n de imaxes"
+msgstr "Presentación de imaxes"
 
 #: src/preferences.py:80
 msgid "Preferences"
@@ -575,12 +575,12 @@ msgstr "Sempre usar esa cor como cor de fondo."
 
 #: src/preferences.py:104
 msgid "Use dynamic background colour."
-msgstr "Usar cor de fondo din�mica."
+msgstr "Usar cor de fondo dinámica."
 
 #: src/preferences.py:108
 msgid "Automatically pick a background colour that fits the viewed image."
 msgstr ""
-"Escoller unha cor de fondo compat�bel coa imaxe visualizada "
+"Escoller unha cor de fondo compatíbel coa imaxe visualizada "
 "automaticamente."
 
 #: src/preferences.py:111
@@ -589,11 +589,11 @@ msgstr "Miniaturas"
 
 #: src/preferences.py:112
 msgid "Thumbnail size (in pixels)"
-msgstr "Tama�o da miniatura (en pixels)"
+msgstr "Tamaño da miniatura (en pixels)"
 
 #: src/preferences.py:119
 msgid "Show page numbers on thumbnails."
-msgstr "Mostrar n�meros de p�xina nas miniaturas."
+msgstr "Mostrar números de páxina nas miniaturas."
 
 #: src/preferences.py:126
 msgid "Magnifying Glass"
@@ -601,14 +601,14 @@ msgstr "Lente de aumento"
 
 #: src/preferences.py:127
 msgid "Magnifying glass size (in pixels)"
-msgstr "Tama�o da lente de aumento (en pixels)"
+msgstr "Tamaño da lente de aumento (en pixels)"
 
 #: src/preferences.py:133
 msgid ""
 "Set the size of the magnifying glass. It is a square with a side of this "
 "many pixels."
 msgstr ""
-"Axustar o tama�o da lente de aumento. � un cadrado con ese tama�o de "
+"Axustar o tamaño da lente de aumento. É un cadrado con ese tamaño de "
 "pixels."
 
 #: src/preferences.py:135
@@ -633,9 +633,9 @@ msgid ""
 "current zoom mode requests it. If this preference is unset, images are never "
 "scaled to be larger than their original size."
 msgstr ""
-"Estricar imaxes para un tama�o que � maior que o seu tama�o original se o "
-"modo de zoom actual o esixe. Se esta preferencia non est� marcada, as "
-"imaxes nunca ser�n vistas nun tama�o maior que o orixinal."
+"Estricar imaxes para un tamaño que é maior que o seu tamaño original se o "
+"modo de zoom actual o esixe. Se esta preferencia non está marcada, as "
+"imaxes nunca serán vistas nun tamaño maior que o orixinal."
 
 #: src/preferences.py:153
 msgid "Transparency"
@@ -651,7 +651,7 @@ msgid ""
 "is unset, the background is plain white instead."
 msgstr ""
 "Usar un fondo cuadriculado cinza para as imaxes transparentes. Se esta "
-"preferencia non estiver marcada, o fondo usado ser� branco."
+"preferencia non estiver marcada, o fondo usado será branco."
 
 #: src/preferences.py:163
 msgid "Appearance"
@@ -659,11 +659,11 @@ msgstr "Aparencia"
 
 #: src/preferences.py:169
 msgid "Scroll"
-msgstr "Progresi�n das imaxes"
+msgstr "Progresión das imaxes"
 
 #: src/preferences.py:171
 msgid "Use smart space key scrolling."
-msgstr "Usar a progresi�n intelixente de imaxes coa tecla de espazo."
+msgstr "Usar a progresión intelixente de imaxes coa tecla de espazo."
 
 #: src/preferences.py:176
 msgid ""
@@ -672,14 +672,14 @@ msgid ""
 "also scrolls sideways and so tries to follow the natural reading order of "
 "the comic book."
 msgstr ""
-"Usar a progresi�n intelixente de imaxes coa tecla de espazo. Normalmente, a tecla de espazo "
-"s� avanza para abaixo (ou para arriba, cando se apreta a tecla de mai�sculas). No entanto, con "
-"esta preferencia tam�n avanzar� para os lados e tentar� seguir a orde natural de "
-"lectura dunha banda dese�ada."
+"Usar a progresión intelixente de imaxes coa tecla de espazo. Normalmente, a tecla de espazo "
+"só avanza para abaixo (ou para arriba, cando se apreta a tecla de maiúsculas). No entanto, con "
+"esta preferencia tamén avanzará para os lados e tentará seguir a orde natural de "
+"lectura dunha banda deseñada."
 
 #: src/preferences.py:180
 msgid "Flip pages when scrolling off the edges of the page."
-msgstr "Pasar as p�xinas cando se avance f�ra do bordo da p�xina."
+msgstr "Pasar as páxinas cando se avance fóra do bordo da páxina."
 
 #: src/preferences.py:185
 msgid ""
@@ -687,28 +687,28 @@ msgid ""
 "arrow keys. It takes three consecutive \"steps\" with the scroll wheel or "
 "the arrow keys for the pages to be flipped."
 msgstr ""
-"Pasar as p�xinas cando cando se avance \"f�ra da p�xina\" coa roda do rato "
-"ou coas teclas do cursor. Ser�n necesarios tres \"pasos\" consecutivos coa roda "
-"do rato ou coas teclas do cursor para pasar as p�xinas."
+"Pasar as páxinas cando cando se avance \"fóra da páxina\" coa roda do rato "
+"ou coas teclas do cursor. Serán necesarios tres \"pasos\" consecutivos coa roda "
+"do rato ou coas teclas do cursor para pasar as páxinas."
 
 #: src/preferences.py:188 src/ui.py:298
 msgid "Double page mode"
-msgstr "Modo de p�xina dobre"
+msgstr "Modo de páxina dobre"
 
 #: src/preferences.py:190
 msgid "Flip two pages in double page mode."
-msgstr "Pasar d�as p�xinas no modo de p�xina dobre."
+msgstr "Pasar dúas páxinas no modo de páxina dobre."
 
 #: src/preferences.py:195
 msgid ""
 "Flip two pages, instead of one, each time we flip pages in double page mode."
 msgstr ""
-"Pasar d�as p�xinas, en lugar dunha, cada vez que se pase p�xina no modo de "
-"p�xina dobre."
+"Pasar dúas páxinas, en lugar dunha, cada vez que se pase páxina no modo de "
+"páxina dobre."
 
 #: src/preferences.py:198
 msgid "Show only one wide image in double page mode."
-msgstr "Mostrar s� unha imaxe larga no modo de p�xina dobre"
+msgstr "Mostrar só unha imaxe larga no modo de páxina dobre"
 
 #: src/preferences.py:204
 msgid ""
@@ -716,9 +716,9 @@ msgid ""
 "height. The result of this is that scans that span two pages are displayed "
 "properly (i.e. alone) also in double page mode."
 msgstr ""
-"Mostra s� unha imaxe no modo de p�xina dobre, se a largura da imaxe excede "
-"da s�a altura. O resultado disto � que as imaxes escaneadas que abranguen d�as p�xinas ser�n "
-"mostrados adecuadamente (isto �, de maneira illada) tam�n no modo de p�xina dobre."
+"Mostra só unha imaxe no modo de páxina dobre, se a largura da imaxe excede "
+"da súa altura. O resultado disto é que as imaxes escaneadas que abranguen dúas páxinas serán "
+"mostrados adecuadamente (isto é, de maneira illada) tamén no modo de páxina dobre."
 
 #: src/preferences.py:207
 msgid "Files"
@@ -726,19 +726,19 @@ msgstr "Arquivos"
 
 #: src/preferences.py:209
 msgid "Automatically open the next archive."
-msgstr "Abrir o pr�ximo arquivo automaticamente."
+msgstr "Abrir o próximo arquivo automaticamente."
 
 #: src/preferences.py:214
 msgid ""
 "Automatically open the next archive in the directory when flipping past the "
 "last page, or the previous archive when flipping past the first page."
 msgstr ""
-"Abre o pr�ximo arquivo do directorio automaticamente cando se pase a "
-"derradeira p�xina, ou o arquivo anterior cando se pase atr�s antes da primeira p�xina."
+"Abre o próximo arquivo do directorio automaticamente cando se pase a "
+"derradeira páxina, ou o arquivo anterior cando se pase atrás antes da primeira páxina."
 
 #: src/preferences.py:217
 msgid "Automatically open the last viewed file on startup."
-msgstr "Abrir o �ltimo arquivo visto automaticamente ao iniciar."
+msgstr "Abrir o último arquivo visto automaticamente ao iniciar."
 
 #: src/preferences.py:222
 msgid ""
@@ -746,18 +746,18 @@ msgid ""
 "closed."
 msgstr ""
 "Abre, cando se inicia, o arquivo que estaba aberto cando o Comix foi fechado "
-"por �ltima vez."
+"por última vez."
 
 #: src/preferences.py:225
 msgid "Store information about recently opened files."
-msgstr "Garda informaci�ns sobre arquivos abertos recentemente."
+msgstr "Garda informacións sobre arquivos abertos recentemente."
 
 #: src/preferences.py:230
 msgid ""
 "Add information about all files opened from within Comix to the shared "
 "recent files list."
 msgstr ""
-"Engadir informaci�ns sobre todos os arquivos abertos dentro do Comix para a "
+"Engadir informacións sobre todos os arquivos abertos dentro do Comix para a "
 "lista de arquivos compartidos recentemente."
 
 #: src/preferences.py:233
@@ -770,17 +770,17 @@ msgid ""
 "specification. These thumbnails are shared by many other applications, such "
 "as most file managers."
 msgstr ""
-"Garda as miniaturas de arquivos abertos de acordo coa especificaci�n do "
+"Garda as miniaturas de arquivos abertos de acordo coa especificación do "
 "freedesktop.org. Esas miniaturas son compartidas por varios outros "
 "programas, como a maior parte dos xestores de arquivos."
 
 #: src/preferences.py:241
 msgid "Cache"
-msgstr "Cach�"
+msgstr "Caché"
 
 #: src/preferences.py:242
 msgid "Use a cache to speed up browsing."
-msgstr "Usar un cach� para aumentar a velocidade de navegaci�n."
+msgstr "Usar un caché para aumentar a velocidade de navegación."
 
 #: src/preferences.py:246
 msgid ""
@@ -789,9 +789,9 @@ msgid ""
 "recommended that you have this preference set, unless you are running short "
 "on free RAM."
 msgstr ""
-"Fai un cach� da imaxes pr�ximas a imaxe vista actualmente para "
-"acelerar a navegaci�n. Xa que a mellora de velocidade � grande, � "
-"recomend�bel ter esta preferencia marcada, ag�s que vostede dispo�a de pouca "
+"Fai un caché da imaxes próximas a imaxe vista actualmente para "
+"acelerar a navegación. Xa que a mellora de velocidade é grande, é "
+"recomendábel ter esta preferencia marcada, agás que vostede dispoña de pouca "
 "memoria RAM no seu ordenador."
 
 #: src/preferences.py:248
@@ -804,7 +804,7 @@ msgstr "Preferencias por defecto"
 
 #: src/preferences.py:256
 msgid "Use double page mode by default."
-msgstr "Usar o modo de p�xina dobre por defecto."
+msgstr "Usar o modo de páxina dobre por defecto."
 
 #: src/preferences.py:261
 msgid "Use fullscreen by default."
@@ -820,7 +820,7 @@ msgstr "Modo de zoom por defecto"
 
 #: src/preferences.py:273 src/ui.py:290
 msgid "Best fit mode"
-msgstr "Modo de encaixe �ptimo"
+msgstr "Modo de encaixe óptimo"
 
 #: src/preferences.py:274 src/ui.py:292
 msgid "Fit width mode"
@@ -844,27 +844,27 @@ msgstr "Esconder todas as barras de ferramentas por defecto no modo de pantalla 
 
 #: src/preferences.py:290
 msgid "Slideshow"
-msgstr "Presentaci�n de imaxes"
+msgstr "Presentación de imaxes"
 
 #: src/preferences.py:291
 msgid "Slideshow delay (in seconds)"
-msgstr "Espera da presentaci�n de imaxes (en segundos)"
+msgstr "Espera da presentación de imaxes (en segundos)"
 
 #: src/preferences.py:300
 msgid "Comment extensions"
-msgstr "Comentar as extensi�ns"
+msgstr "Comentar as extensións"
 
 #: src/preferences.py:306
 msgid ""
 "Treat all files found within archives, that have one of these file endings, "
 "as comments."
 msgstr ""
-"Tratar todos os documentos atopados dentro de arquivos, inclu�ndo os que te�en "
-"estas terminaci�ns de arquivo, como comentarios."
+"Tratar todos os documentos atopados dentro de arquivos, incluíndo os que teñen "
+"estas terminacións de arquivo, como comentarios."
 
 #: src/preferences.py:309
 msgid "Rotation"
-msgstr "Rotaci�n"
+msgstr "Rotación"
 
 #: src/preferences.py:311
 msgid "Automatically rotate images according to their metadata."
@@ -874,12 +874,12 @@ msgstr "Rotar automaticamente as imaxes segundo os seus metadatos"
 msgid ""
 "Automatically rotate images when an orientation is specified in the image "
 "metadata, such as in an Exif tag."
-msgstr "Rotar automaticamente as imaxes cando a orientaci�n se especifique "
+msgstr "Rotar automaticamente as imaxes cando a orientación se especifique "
 "nos metadatos, como no caso dos tag Exif."
 
 #: src/preferences.py:318
 msgid "Display"
-msgstr "Superficie de visualizaci�n"
+msgstr "Superficie de visualización"
 
 #: src/properties.py:94
 msgid "Properties"
@@ -920,7 +920,7 @@ msgstr "Imaxe"
 
 #: src/thumbremover.py:24
 msgid "Thumbnail maintenance"
-msgstr "Manutenci�n de miniaturas"
+msgstr "Manutención de miniaturas"
 
 #: src/thumbremover.py:26
 msgid "Cleanup"
@@ -938,11 +938,11 @@ msgid ""
 "files have been removed - wasting space. This dialog can cleanup your stored "
 "thumbnails by removing orphaned and outdated thumbnails."
 msgstr ""
-"As miniaturas para os arquivos (como arquivos de imaxes e bandas dese�adas "
-"ser�n gardadas no seu directorio de usuario. Moitos programas "
+"As miniaturas para os arquivos (como arquivos de imaxes e bandas deseñadas "
+"serán gardadas no seu directorio de usuario. Moitos programas "
 "diferentes usan e crean esas miniaturas, mais algunhas veces as miniaturas "
 "permanecen cando os arquivos orixinais son eliminados - "
-"desperdiciando espazo. Este di�logo pode limpar as miniaturas ao eliminar "
+"desperdiciando espazo. Este diálogo pode limpar as miniaturas ao eliminar "
 "minaturas orfas e obsoletas."
 
 #: src/thumbremover.py:60
@@ -951,7 +951,7 @@ msgstr "Directorio de miniaturas"
 
 #: src/thumbremover.py:67
 msgid "Total number of thumbnails"
-msgstr "N�mero total de miniaturas"
+msgstr "Número total de miniaturas"
 
 #: src/thumbremover.py:70 src/thumbremover.py:77
 msgid "Calculating..."
@@ -959,7 +959,7 @@ msgstr "Calculando..."
 
 #: src/thumbremover.py:74
 msgid "Total size of thumbnails"
-msgstr "Tama�o total das miniaturas"
+msgstr "Tamaño total das miniaturas"
 
 #: src/thumbremover.py:82
 msgid "Do you want to cleanup orphaned and outdated thumbnails now?"
@@ -971,11 +971,11 @@ msgstr "Eliminando miniaturas"
 
 #: src/thumbremover.py:137
 msgid "Number of removed thumbnails"
-msgstr "N�mero de miniaturas eliminadas"
+msgstr "Número de miniaturas eliminadas"
 
 #: src/thumbremover.py:144
 msgid "Total size of removed thumbnails"
-msgstr "Tama�o total das miniaturas eliminadas"
+msgstr "Tamaño total das miniaturas eliminadas"
 
 #: src/thumbremover.py:195
 #, python-format
@@ -984,19 +984,19 @@ msgstr "Eliminada a miniatura de '{}'"
 
 #: src/ui.py:34
 msgid "_Next page"
-msgstr "_Pr�xima p�xina"
+msgstr "_Próxima páxina"
 
 #: src/ui.py:36
 msgid "_Previous page"
-msgstr "P�_xina anterior"
+msgstr "Pá_xina anterior"
 
 #: src/ui.py:38
 msgid "_First page"
-msgstr "P_rimeira p�xina"
+msgstr "P_rimeira páxina"
 
 #: src/ui.py:40
 msgid "_Last page"
-msgstr "_Ultima p�xina"
+msgstr "_Ultima páxina"
 
 #: src/ui.py:42
 msgid "_Zoom in"
@@ -1008,7 +1008,7 @@ msgstr "_Diminuir zoom"
 
 #: src/ui.py:46
 msgid "O_riginal size"
-msgstr "Tama�o _orixinal"
+msgstr "Tamaño _orixinal"
 
 #: src/ui.py:48
 msgid "_Close"
@@ -1016,19 +1016,19 @@ msgstr "_Fechar"
 
 #: src/ui.py:50
 msgid "_Quit"
-msgstr "_Sa�r"
+msgstr "_Saír"
 
 #: src/ui.py:52
 msgid "_Rotate 90 degrees CW"
-msgstr "Ro_taci�n de 90 graos horarios"
+msgstr "Ro_tación de 90 graos horarios"
 
 #: src/ui.py:54
 msgid "Rotate 180 de_grees"
-msgstr "Rotaci�n de 180 graos horarios"
+msgstr "Rotación de 180 graos horarios"
 
 #: src/ui.py:56
 msgid "Rotat_e 90 degrees CCW"
-msgstr "Ro_taci�n de 90 graos antihorarios"
+msgstr "Ro_tación de 90 graos antihorarios"
 
 #: src/ui.py:58
 msgid "Fli_p horizontally"
@@ -1084,7 +1084,7 @@ msgstr "_Pantalla completa"
 
 #: src/ui.py:77
 msgid "_Double page mode"
-msgstr "Modo de p�xina _dobre"
+msgstr "Modo de páxina _dobre"
 
 #: src/ui.py:79
 msgid "_Toolbar"
@@ -1116,11 +1116,11 @@ msgstr "_Modo manga"
 
 #: src/ui.py:93
 msgid "_Keep transformation"
-msgstr "_Manter a transformaci�n"
+msgstr "_Manter a transformación"
 
 #: src/ui.py:95
 msgid "Run _slideshow"
-msgstr "Come_zar a presentaci�n de imaxes"
+msgstr "Come_zar a presentación de imaxes"
 
 #: src/ui.py:97
 msgid "Magnifying _glass"
@@ -1128,7 +1128,7 @@ msgstr "_Lente de aumento"
 
 #: src/ui.py:103
 msgid "_Best fit mode"
-msgstr "Modo de axuste �_ptimo"
+msgstr "Modo de axuste ó_ptimo"
 
 #: src/ui.py:105
 msgid "Fit _width mode"
@@ -1168,7 +1168,7 @@ msgstr "_Mellorar imaxe..."
 
 #: src/ui.py:128
 msgid "_Thumbnail maintenance..."
-msgstr "Manu_tenci�n de miniaturas..."
+msgstr "Manu_tención de miniaturas..."
 
 #: src/ui.py:130
 msgid "Pr_eferences"
@@ -1180,19 +1180,19 @@ msgstr "Bib_lioteca..."
 
 #: src/ui.py:284
 msgid "First page"
-msgstr "Primeira p�xina"
+msgstr "Primeira páxina"
 
 #: src/ui.py:286
 msgid "Previous page"
-msgstr "P�xina anterior"
+msgstr "Páxina anterior"
 
 #: src/ui.py:287
 msgid "Next page"
-msgstr "Pr�xima p�xina"
+msgstr "Próxima páxina"
 
 #: src/ui.py:288
 msgid "Last page"
-msgstr "�ltima p�xina"
+msgstr "Última páxina"
 
 #: src/ui.py:299
 msgid "Manga mode"

--- a/messages/hr/LC_MESSAGES/comix.po
+++ b/messages/hr/LC_MESSAGES/comix.po
@@ -286,8 +286,8 @@ msgstr "Komentari"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Neuspješno čitanje %s"
+msgid "Could not read {}"
+msgstr "Neuspješno čitanje {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -475,8 +475,8 @@ msgstr "Tar arhive"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Datoteka imena '%s' već postoji. Želite je zamijeniti?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Datoteka imena '{}' već postoji. Želite je zamijeniti?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -515,36 +515,36 @@ msgstr "Automatski pridodaj knjige ovoj zbirci"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Nemoguće otvoriti %s: To je direktorij."
+msgid "Could not open {}: Is a directory."
+msgstr "Nemoguće otvoriti {}: To je direktorij."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Nemoguće otvoriti %s: Datoteka ne postoji."
+msgid "Could not open {}: No such file."
+msgstr "Nemoguće otvoriti {}: Datoteka ne postoji."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Nemoguće otvoriti %s: Pristup odbijen."
+msgid "Could not open {}: Permission denied."
+msgstr "Nemoguće otvoriti {}: Pristup odbijen."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Nemoguće otvoriti %s: Nepoznat tip datoteke."
+msgid "Could not open {}: Unknown file type."
+msgstr "Nemoguće otvoriti {}: Nepoznat tip datoteke."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Nema slika u '%s'"
+msgid "No images in '{}'"
+msgstr "Nema slika u '{}'"
 
 #
 # File: src/filehandler.py, line: 411
@@ -621,8 +621,8 @@ msgstr "Unesite novo ime za označenu kolekciju."
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Nemoguće promijeniti ime u '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Nemoguće promijeniti ime u '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -648,25 +648,25 @@ msgstr "Korijen"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "Stavi kolekciju '%(subcollection)s' u kolekciju '%(supercollection)s'."
+msgstr "Stavi kolekciju '{subcollection}' u kolekciju '{supercollection}'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Dodaj knjige u '%s'."
+msgid "Add books to '{}'."
+msgstr "Dodaj knjige u '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Premjesti knjige iz '%(source collection)s' u '%(destination collection)s'."
+"Premjesti knjige iz '{source collection}' u '{destination collection}'."
 
 #
 # File: src/library.py, line: 492
@@ -684,8 +684,8 @@ msgstr "Obriši iz biblioteke..."
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Obrisano %(num)d knjiga iz '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Obrisano {num} knjiga iz '{collection}'."
 
 #
 # File: src/library.py, line: 597
@@ -707,8 +707,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Obrisano %d knjiga iz biblioteke."
+msgid "Removed {} book(s) from the library."
+msgstr "Obrisano {} knjiga iz biblioteke."
 
 #
 # File: src/library.py, line: 769
@@ -767,8 +767,8 @@ msgstr "Otvori označenu knjigu."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d stranica"
+msgid "{} pages"
+msgstr "{} stranica"
 
 #
 # File: src/library.py, line: 854
@@ -792,8 +792,8 @@ msgstr "Nova kolekcija"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Nemoguće dodati novu kolekciju imena '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Nemoguće dodati novu kolekciju imena '{}'."
 
 #
 # File: src/library.py, line: 910
@@ -811,8 +811,8 @@ msgstr "Dodane knjige"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Dodajem '%s'..."
+msgid "Adding '{}'..."
+msgstr "Dodajem '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -1271,8 +1271,8 @@ msgstr "Svojstva"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d komentara"
+msgid "{} comments"
+msgstr "{} komentara"
 
 #
 # File: src/properties.py, line: 124
@@ -1408,8 +1408,8 @@ msgstr "Ukupna veličina obrisanih sličica"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Obrisana sličica za '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Obrisana sličica za '{}'"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/hu/LC_MESSAGES/comix.po
+++ b/messages/hu/LC_MESSAGES/comix.po
@@ -195,8 +195,8 @@ msgstr "Megjegyzések"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Nem olvasható a(z) %s"
+msgid "Could not read {}"
+msgstr "Nem olvasható a(z) {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -325,8 +325,8 @@ msgstr "Tar archívumok"
 
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "A megadott nevű állomány már létezik: '%s'. Akarja a cserét?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "A megadott nevű állomány már létezik: '{}'. Akarja a cserét?"
 
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
@@ -350,28 +350,28 @@ msgstr "A könyveket automatikusan adja hozzá az aktuális gyűjteményhez."
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "%s-t nem lehet megnyitni: Ez egy könyvtár."
+msgid "Could not open {}: Is a directory."
+msgstr "{}-t nem lehet megnyitni: Ez egy könyvtár."
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "%s-t nem lehet megnyitni: Nincs ilyen fájl."
+msgid "Could not open {}: No such file."
+msgstr "{}-t nem lehet megnyitni: Nincs ilyen fájl."
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "%s-t nem lehet megnyitni: Hozzáférés megtagadva."
+msgid "Could not open {}: Permission denied."
+msgstr "{}-t nem lehet megnyitni: Hozzáférés megtagadva."
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "%s-t nem lehet megnyitni: Ismeretlen fájltípus."
+msgid "Could not open {}: Unknown file type."
+msgstr "{}-t nem lehet megnyitni: Ismeretlen fájltípus."
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Nincsenek képek a következő helyen: '%s'"
+msgid "No images in '{}'"
+msgstr "Nincsenek képek a következő helyen: '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -423,8 +423,8 @@ msgstr "Adja meg a kiválasztott gyűjtemény új nevét."
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "A nevet nem lehet megváltoztatni a következőre: '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "A nevet nem lehet megváltoztatni a következőre: '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
@@ -441,23 +441,23 @@ msgstr "Alapkönyvtár"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"A '%(subcollection)s' gyűjtemény áthelyezése a következőbe: '%"
+"A '{subcollection}' gyűjtemény áthelyezése a következőbe: '%"
 "(supercollection)s'."
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Könyvek hozzáadása a következőhöz: '%s'."
+msgid "Add books to '{}'."
+msgstr "Könyvek hozzáadása a következőhöz: '{}'."
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Könyvek mozgatása innen: '%(source collection)s' ide: '%(destination "
+"Könyvek mozgatása innen: '{source collection}' ide: '%(destination "
 "collection)s'."
 
 #: src/library.py:493
@@ -470,8 +470,8 @@ msgstr "Eltávolítás a könyvtárból."
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Removed %(num)d book(s) from '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Removed {num} book(s) from '{collection}'."
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -487,8 +487,8 @@ msgstr ""
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "A könyvtárból eltávolítva a következő(k): %d."
+msgid "Removed {} book(s) from the library."
+msgstr "A könyvtárból eltávolítva a következő(k): {}."
 
 #: src/library.py:770
 msgid "Search"
@@ -528,8 +528,8 @@ msgstr "A kiválasztott könyv megnyitása."
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d lapok"
+msgid "{} pages"
+msgstr "{} lapok"
 
 #: src/library.py:855
 msgid "Add new collection?"
@@ -545,8 +545,8 @@ msgstr "Új gyűjtemény."
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Nem lehetett hozzáadni a '%s' nevű gyűjteményt."
+msgid "Could not add a new collection called '{}'."
+msgstr "Nem lehetett hozzáadni a '{}' nevű gyűjteményt."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -558,8 +558,8 @@ msgstr "Hozzáadott könyvek"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Hozzáadás '%s'..."
+msgid "Adding '{}'..."
+msgstr "Hozzáadás '{}'..."
 
 #: src/main.py:704
 msgid "SLIDESHOW"
@@ -898,8 +898,8 @@ msgstr "Tulajdonságok"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "Megjegyzések: %d"
+msgid "{} comments"
+msgstr "Megjegyzések: {}"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -989,8 +989,8 @@ msgstr "Az eltávolított bélyegképek mérete"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "'%s' - eltávolított bélyegképek"
+msgid "Removed thumbnail for '{}'"
+msgstr "'{}' - eltávolított bélyegképek"
 
 #: src/ui.py:34
 msgid "_Next page"

--- a/messages/hu/LC_MESSAGES/comix.po
+++ b/messages/hu/LC_MESSAGES/comix.po
@@ -444,8 +444,7 @@ msgid ""
 "Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"A '{subcollection}' gyűjtemény áthelyezése a következőbe: '%"
-"(supercollection)s'."
+"A '{subcollection}' gyűjtemény áthelyezése a következőbe: '{supercollection}'."
 
 #: src/library.py:407
 #, python-format
@@ -457,8 +456,7 @@ msgstr "Könyvek hozzáadása a következőhöz: '{}'."
 msgid ""
 "Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Könyvek mozgatása innen: '{source collection}' ide: '%(destination "
-"collection)s'."
+"Könyvek mozgatása innen: '{source collection}' ide: '{destination collection}'."
 
 #: src/library.py:493
 msgid "Remove from this collection"

--- a/messages/id/LC_MESSAGES/comix.po
+++ b/messages/id/LC_MESSAGES/comix.po
@@ -288,8 +288,8 @@ msgstr "Komentar"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Tak dapat membaca %s"
+msgid "Could not read {}"
+msgstr "Tak dapat membaca {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -477,8 +477,8 @@ msgstr "Arsip Tar"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Berkas bernama '%s' telah ada. Anda ingin menggantinya?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Berkas bernama '{}' telah ada. Anda ingin menggantinya?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -517,36 +517,36 @@ msgstr "Otomatis menambah buku ke koleksi ini"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Tak dapat membuka %s: Sebuah direktori."
+msgid "Could not open {}: Is a directory."
+msgstr "Tak dapat membuka {}: Sebuah direktori."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Tak dapat membuka %s: Tak ada berkas."
+msgid "Could not open {}: No such file."
+msgstr "Tak dapat membuka {}: Tak ada berkas."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Tak dapat membuka %s: Hak akses ditolak."
+msgid "Could not open {}: Permission denied."
+msgstr "Tak dapat membuka {}: Hak akses ditolak."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Tak dapat membuka %s: Tipe berkas tak diketahui."
+msgid "Could not open {}: Unknown file type."
+msgstr "Tak dapat membuka {}: Tipe berkas tak diketahui."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Tak ada citra di '%s'"
+msgid "No images in '{}'"
+msgstr "Tak ada citra di '{}'"
 
 #
 # File: src/filehandler.py, line: 411
@@ -623,8 +623,8 @@ msgstr "Silakan masukkan nama baru untuk koleksi terpilih."
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Tak dapat mengubah nama ke '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Tak dapat mengubah nama ke '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -650,25 +650,25 @@ msgstr "Root"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "Taruh koleksi '%(subcollection)s' di koleksi '%(supercollection)s'."
+msgstr "Taruh koleksi '{subcollection}' di koleksi '{supercollection}'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Tambah buku ke '%s'."
+msgid "Add books to '{}'."
+msgstr "Tambah buku ke '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Pindah buku dari '%(source collection)s' ke '%(destination collection)s'."
+"Pindah buku dari '{source collection}' ke '{destination collection}'."
 
 #
 # File: src/library.py, line: 492
@@ -686,8 +686,8 @@ msgstr "Hapus dari pustaka..."
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Hapus %(num)d buku dari '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Hapus {num} buku dari '{collection}'."
 
 #
 # File: src/library.py, line: 597
@@ -709,8 +709,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Hapus %d buku dari pustaka."
+msgid "Removed {} book(s) from the library."
+msgstr "Hapus {} buku dari pustaka."
 
 #
 # File: src/library.py, line: 769
@@ -769,8 +769,8 @@ msgstr "Buka buku terpilih."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d halaman"
+msgid "{} pages"
+msgstr "{} halaman"
 
 #
 # File: src/library.py, line: 854
@@ -794,8 +794,8 @@ msgstr "Koleksi baru"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Tak dapat menambah koleksi baru bernama '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Tak dapat menambah koleksi baru bernama '{}'."
 
 #
 # File: src/library.py, line: 910
@@ -813,8 +813,8 @@ msgstr "Buku yang ditambah"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Menambah '%s'..."
+msgid "Adding '{}'..."
+msgstr "Menambah '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -1277,8 +1277,8 @@ msgstr "Properti"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d komentar"
+msgid "{} comments"
+msgstr "{} komentar"
 
 #
 # File: src/properties.py, line: 124
@@ -1414,8 +1414,8 @@ msgstr "Ukuran total miniatur yang dihapus"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Hapus miniatur untuk '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Hapus miniatur untuk '{}'"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/it/LC_MESSAGES/comix.po
+++ b/messages/it/LC_MESSAGES/comix.po
@@ -278,7 +278,7 @@ msgstr "Commenti"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
+msgid "Could not read {}"
 msgstr ""
 
 #
@@ -458,7 +458,7 @@ msgstr ""
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
 msgstr ""
 
 #
@@ -498,35 +498,35 @@ msgstr ""
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
+msgid "Could not open {}: Is a directory."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
+msgid "Could not open {}: No such file."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
+msgid "Could not open {}: Permission denied."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
+msgid "Could not open {}: Unknown file type."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
+msgid "No images in '{}'"
 msgstr ""
 
 #
@@ -602,7 +602,7 @@ msgstr ""
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
+msgid "Could not change the name to '{}'."
 msgstr ""
 
 #
@@ -629,7 +629,7 @@ msgstr ""
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
+msgid "Add books to '{}'."
 msgstr ""
 
 #
@@ -645,7 +645,7 @@ msgstr ""
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
 
 #
@@ -664,7 +664,7 @@ msgstr ""
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
 msgstr ""
 
 #
@@ -685,7 +685,7 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
+msgid "Removed {} book(s) from the library."
 msgstr ""
 
 #
@@ -743,7 +743,7 @@ msgstr ""
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
+msgid "{} pages"
 msgstr ""
 
 #
@@ -768,7 +768,7 @@ msgstr ""
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
+msgid "Could not add a new collection called '{}'."
 msgstr ""
 
 #
@@ -787,7 +787,7 @@ msgstr ""
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
+msgid "Adding '{}'..."
 msgstr ""
 
 #
@@ -1214,7 +1214,7 @@ msgstr "Proprietà"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
+msgid "{} comments"
 msgstr ""
 
 #
@@ -1346,7 +1346,7 @@ msgstr ""
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
+msgid "Removed thumbnail for '{}'"
 msgstr ""
 
 #
@@ -1680,8 +1680,8 @@ msgid "Magnifying glass"
 msgstr ""
 
 #
-#~ msgid "No images in \"%s\""
-#~ msgstr "Nessuna immagine in \"%s\""
+#~ msgid "No images in \"{}\""
+#~ msgstr "Nessuna immagine in \"{}\""
 
 #
 #~ msgid "Default"
@@ -2091,20 +2091,20 @@ msgstr ""
 #~ msgstr "Conferma operazione"
 
 #
-#~ msgid "Permanently remove %s?"
-#~ msgstr "Rimuovi permanentemente %s?"
+#~ msgid "Permanently remove {}?"
+#~ msgstr "Rimuovi permanentemente {}?"
 
 #
-#~ msgid "Perform lossless JPEG operation on %s?"
-#~ msgstr "Esegui operazione JPEG lossless su %s?"
+#~ msgid "Perform lossless JPEG operation on {}?"
+#~ msgstr "Esegui operazione JPEG lossless su {}?"
 
 #
 #~ msgid "Some images might be trimmed a bit during the operation."
 #~ msgstr "Alcune immagini potrebbero venir tagliate durante l'operazione."
 
 #
-#~ msgid "Permanently convert %s to greyscale?"
-#~ msgstr "Converti permanentemente %s in scala di grigi?"
+#~ msgid "Permanently convert {} to greyscale?"
+#~ msgstr "Converti permanentemente {} in scala di grigi?"
 
 #
 #~ msgid "Location:"

--- a/messages/ja/LC_MESSAGES/comix.po
+++ b/messages/ja/LC_MESSAGES/comix.po
@@ -282,8 +282,8 @@ msgstr "コメント"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "%sを読めませんでした"
+msgid "Could not read {}"
+msgstr "{}を読めませんでした"
 
 #
 # File: src/deprecated.py, line: 16
@@ -468,8 +468,8 @@ msgstr "Tar書庫ファイル"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "'%s'という名前のファイルは既に存在します。上書きしますか？"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "'{}'という名前のファイルは既に存在します。上書きしますか？"
 
 #
 # File: src/filechooser.py, line: 128
@@ -508,36 +508,36 @@ msgstr "本を自動的にこのコレクションに追加する"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "'%s'を開けませんでした。ディレクトリです。"
+msgid "Could not open {}: Is a directory."
+msgstr "'{}'を開けませんでした。ディレクトリです。"
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "'%s'を開けませんでした。ファイルが存在しません。"
+msgid "Could not open {}: No such file."
+msgstr "'{}'を開けませんでした。ファイルが存在しません。"
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "'%s'を開けませんでした。パーミッションが許可されていません。"
+msgid "Could not open {}: Permission denied."
+msgstr "'{}'を開けませんでした。パーミッションが許可されていません。"
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "'%s'を開けませんでした。ファイル形式が分かりません。"
+msgid "Could not open {}: Unknown file type."
+msgstr "'{}'を開けませんでした。ファイル形式が分かりません。"
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "'%s'の中には画像がありません"
+msgid "No images in '{}'"
+msgstr "'{}'の中には画像がありません"
 
 #
 # File: src/filehandler.py, line: 411
@@ -614,8 +614,8 @@ msgstr "選択されたコレクションの新しい名前を入力してくだ
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "'%s'の名前を変更出来ませんでした。"
+msgid "Could not change the name to '{}'."
+msgstr "'{}'の名前を変更出来ませんでした。"
 
 #
 # File: src/library.py, line: 275
@@ -641,27 +641,27 @@ msgstr "ルート"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"コレクション '%(subcollection)s' をコレクション '%(supercollection)s' の中に"
+"コレクション '{subcollection}' をコレクション '{supercollection}' の中に"
 "入れる"
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "本を'%s'に加える"
+msgid "Add books to '{}'."
+msgstr "本を'{}'に加える"
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"本をコレクション'%(source collection)s'から'%(destination collection)s'に移動"
+"本をコレクション'{source collection}'から'{destination collection}'に移動"
 "させる"
 
 #
@@ -680,8 +680,8 @@ msgstr "ライブラリから削除..."
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "%(num)d 個の本が '%(collection)s'から削除されました。"
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "{num} 個の本が '{collection}'から削除されました。"
 
 #
 # File: src/library.py, line: 597
@@ -703,8 +703,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "%d 個の本がライブラリから削除されました。"
+msgid "Removed {} book(s) from the library."
+msgstr "{} 個の本がライブラリから削除されました。"
 
 #
 # File: src/library.py, line: 769
@@ -763,8 +763,8 @@ msgstr "選択した本を開く"
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d ページ"
+msgid "{} pages"
+msgstr "{} ページ"
 
 #
 # File: src/library.py, line: 854
@@ -788,8 +788,8 @@ msgstr "新しいコレクション"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "'%s'という名前の新しいコレクションを追加出来ませんでした。"
+msgid "Could not add a new collection called '{}'."
+msgstr "'{}'という名前の新しいコレクションを追加出来ませんでした。"
 
 #
 # File: src/library.py, line: 910
@@ -807,8 +807,8 @@ msgstr "本を追加しました"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "'%s'を追加中..."
+msgid "Adding '{}'..."
+msgstr "'{}'を追加中..."
 
 #
 # File: src/main.py, line: 666
@@ -1264,8 +1264,8 @@ msgstr "プロパティ"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d個のコメント"
+msgid "{} comments"
+msgstr "{}個のコメント"
 
 #
 # File: src/properties.py, line: 124
@@ -1401,8 +1401,8 @@ msgstr "削除されたサムネイルの合計サイズ"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "'%s'のサムネイルを削除しました"
+msgid "Removed thumbnail for '{}'"
+msgstr "'{}'のサムネイルを削除しました"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/ko/LC_MESSAGES/comix.po
+++ b/messages/ko/LC_MESSAGES/comix.po
@@ -279,8 +279,8 @@ msgstr "주석"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "읽을 수 없습니다. %s"
+msgid "Could not read {}"
+msgstr "읽을 수 없습니다. {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -463,8 +463,8 @@ msgstr "Tar 압축파일"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "'%s' 파일이 이미 있습니다. 덮어씌우시겟습니까?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "'{}' 파일이 이미 있습니다. 덮어씌우시겟습니까?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -503,36 +503,36 @@ msgstr "모음집에 자동으로 만화책을 추가"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "디렉토리를 열 수 없습니다. %s"
+msgid "Could not open {}: Is a directory."
+msgstr "디렉토리를 열 수 없습니다. {}"
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "파일을 열 수 없습니다. %s"
+msgid "Could not open {}: No such file."
+msgstr "파일을 열 수 없습니다. {}"
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "퍼미션 거부. %s"
+msgid "Could not open {}: Permission denied."
+msgstr "퍼미션 거부. {}"
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "알 수없는 파일 형식. %s"
+msgid "Could not open {}: Unknown file type."
+msgstr "알 수없는 파일 형식. {}"
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "이미지가 없습니다. %s"
+msgid "No images in '{}'"
+msgstr "이미지가 없습니다. {}"
 
 #
 # File: src/filehandler.py, line: 411
@@ -609,8 +609,8 @@ msgstr "선택된 모음집에 대한 새 이름을 입력하시기 바랍니다
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "이름을 변경하지 못했습니다. '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "이름을 변경하지 못했습니다. '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -636,25 +636,25 @@ msgstr "관리자"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "'%(subcollection)s' 모음집을 '%(supercollection)s' 모음집에 넣기."
+msgstr "'{subcollection}' 모음집을 '{supercollection}' 모음집에 넣기."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "만화책 추가 '%s'."
+msgid "Add books to '{}'."
+msgstr "만화책 추가 '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"'%(source collection)s' 에서 '%(destination collection)s' 으로 만화책 이동."
+"'{source collection}' 에서 '{destination collection}' 으로 만화책 이동."
 
 #
 # File: src/library.py, line: 492
@@ -672,8 +672,8 @@ msgstr "라이브러리에서 제거"
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "'%(collection)s' 에서 %(num)d  만화책 제거."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "'{collection}' 에서 {num}  만화책 제거."
 
 #
 # File: src/library.py, line: 597
@@ -695,8 +695,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "라이브러리에서 %d 만화책을 제거"
+msgid "Removed {} book(s) from the library."
+msgstr "라이브러리에서 {} 만화책을 제거"
 
 #
 # File: src/library.py, line: 769
@@ -755,8 +755,8 @@ msgstr "선택한 만화책 열기"
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d 페이지"
+msgid "{} pages"
+msgstr "{} 페이지"
 
 #
 # File: src/library.py, line: 854
@@ -780,8 +780,8 @@ msgstr "새 모음집"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "새 모음집을 추가하지 못했습니다. '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "새 모음집을 추가하지 못했습니다. '{}'."
 
 #
 # File: src/library.py, line: 910
@@ -799,8 +799,8 @@ msgstr "만화책 추가"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "추가 '%s'..."
+msgid "Adding '{}'..."
+msgstr "추가 '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -1241,8 +1241,8 @@ msgstr "등록정보"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d 주석"
+msgid "{} comments"
+msgstr "{} 주석"
 
 #
 # File: src/properties.py, line: 124
@@ -1377,8 +1377,8 @@ msgstr "미리보기 총 크기 제거"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "미리보기 제거 '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "미리보기 제거 '{}'"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/messages.pot
+++ b/messages/messages.pot
@@ -179,7 +179,7 @@ msgstr ""
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
+msgid "Could not read {)"
 msgstr ""
 
 #: src/deprecated.py:16
@@ -301,7 +301,7 @@ msgstr ""
 
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
+msgid "A file named '{)' already exists. Do you want to replace it?"
 msgstr ""
 
 #: src/filechooser.py:142
@@ -326,27 +326,27 @@ msgstr ""
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
+msgid "Could not open {): Is a directory."
 msgstr ""
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
+msgid "Could not open {): No such file."
 msgstr ""
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
+msgid "Could not open {): Permission denied."
 msgstr ""
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
+msgid "Could not open {): Unknown file type."
 msgstr ""
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
+msgid "No images in '{)'"
 msgstr ""
 
 #: src/filehandler.py:413
@@ -397,7 +397,7 @@ msgstr ""
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
+msgid "Could not change the name to '{)'."
 msgstr ""
 
 #: src/library.py:275 src/library.py:882
@@ -415,19 +415,19 @@ msgstr ""
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
+msgid "Add books to '{)'."
 msgstr ""
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
 
 #: src/library.py:493
@@ -440,7 +440,7 @@ msgstr ""
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
 msgstr ""
 
 #: src/library.py:598
@@ -455,7 +455,7 @@ msgstr ""
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
+msgid "Removed {} book(s) from the library."
 msgstr ""
 
 #: src/library.py:770
@@ -494,7 +494,7 @@ msgstr ""
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
+msgid "{} pages"
 msgstr ""
 
 #: src/library.py:855
@@ -511,7 +511,7 @@ msgstr ""
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
+msgid "Could not add a new collection called '{)'."
 msgstr ""
 
 #: src/library.py:911
@@ -524,7 +524,7 @@ msgstr ""
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
+msgid "Adding '{)'..."
 msgstr ""
 
 #: src/main.py:704
@@ -824,7 +824,7 @@ msgstr ""
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
+msgid "{} comments"
 msgstr ""
 
 #: src/properties.py:129 src/properties.py:164
@@ -910,7 +910,7 @@ msgstr ""
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
+msgid "Removed thumbnail for '{)'"
 msgstr ""
 
 #: src/ui.py:34

--- a/messages/nl/LC_MESSAGES/comix.po
+++ b/messages/nl/LC_MESSAGES/comix.po
@@ -281,7 +281,7 @@ msgstr "Commentaar"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
+msgid "Could not read {}"
 msgstr ""
 
 #
@@ -461,7 +461,7 @@ msgstr ""
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
 msgstr ""
 
 #
@@ -501,35 +501,35 @@ msgstr ""
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
+msgid "Could not open {}: Is a directory."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
+msgid "Could not open {}: No such file."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
+msgid "Could not open {}: Permission denied."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
+msgid "Could not open {}: Unknown file type."
 msgstr ""
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
+msgid "No images in '{}'"
 msgstr ""
 
 #
@@ -605,7 +605,7 @@ msgstr ""
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
+msgid "Could not change the name to '{}'."
 msgstr ""
 
 #
@@ -632,7 +632,7 @@ msgstr ""
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
 
@@ -640,7 +640,7 @@ msgstr ""
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
+msgid "Add books to '{}'."
 msgstr ""
 
 #
@@ -648,7 +648,7 @@ msgstr ""
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
 
 #
@@ -667,7 +667,7 @@ msgstr ""
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
 msgstr ""
 
 #
@@ -688,7 +688,7 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
+msgid "Removed {} book(s) from the library."
 msgstr ""
 
 #
@@ -746,7 +746,7 @@ msgstr ""
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
+msgid "{} pages"
 msgstr ""
 
 #
@@ -771,7 +771,7 @@ msgstr ""
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
+msgid "Could not add a new collection called '{}'."
 msgstr ""
 
 #
@@ -790,7 +790,7 @@ msgstr ""
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
+msgid "Adding '{}'..."
 msgstr ""
 
 #
@@ -1217,7 +1217,7 @@ msgstr "Eigenschappen"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
+msgid "{} comments"
 msgstr ""
 
 #
@@ -1349,7 +1349,7 @@ msgstr ""
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
+msgid "Removed thumbnail for '{}'"
 msgstr ""
 
 #
@@ -1683,8 +1683,8 @@ msgid "Magnifying glass"
 msgstr ""
 
 #
-#~ msgid "No images in \"%s\""
-#~ msgstr "Geen afbeeldingen in \"%s\""
+#~ msgid "No images in \"{}\""
+#~ msgstr "Geen afbeeldingen in \"{}\""
 
 #
 #~ msgid "Default"
@@ -2087,12 +2087,12 @@ msgstr ""
 #~ msgstr "Bevestig actie"
 
 #
-#~ msgid "Permanently remove %s?"
-#~ msgstr "%s permanent verwijderen?"
+#~ msgid "Permanently remove {}?"
+#~ msgstr "{} permanent verwijderen?"
 
 #
-#~ msgid "Perform lossless JPEG operation on %s?"
-#~ msgstr "JPEG actie zonder kwaliteitsverlies toepassen op %s?"
+#~ msgid "Perform lossless JPEG operation on {}?"
+#~ msgstr "JPEG actie zonder kwaliteitsverlies toepassen op {}?"
 
 #
 #~ msgid "Some images might be trimmed a bit during the operation."
@@ -2101,8 +2101,8 @@ msgstr ""
 #~ "transformatie."
 
 #
-#~ msgid "Permanently convert %s to greyscale?"
-#~ msgstr "%s permanent naar grijswaarden omzetten?"
+#~ msgid "Permanently convert {} to greyscale?"
+#~ msgstr "{} permanent naar grijswaarden omzetten?"
 
 #
 #~ msgid "Location:"

--- a/messages/pl/LC_MESSAGES/comix.po
+++ b/messages/pl/LC_MESSAGES/comix.po
@@ -286,8 +286,8 @@ msgstr "Uwagi"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Nie mozna odczytać %s"
+msgid "Could not read {}"
+msgstr "Nie mozna odczytać {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -475,8 +475,8 @@ msgstr "Archiwa TAR"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Plik o nazwie „%s“ już istnieje. Czy chcesz go nadpisać?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Plik o nazwie „{}“ już istnieje. Czy chcesz go nadpisać?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -515,36 +515,36 @@ msgstr "Automatycznie dodaj ksiązki do tej kolekcji"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Nie można otworzyć %s: Jest katalogiem."
+msgid "Could not open {}: Is a directory."
+msgstr "Nie można otworzyć {}: Jest katalogiem."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Nie można otworzyć %s: Brak pliku."
+msgid "Could not open {}: No such file."
+msgstr "Nie można otworzyć {}: Brak pliku."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Nie można otworzyć %s: Brak dostępu."
+msgid "Could not open {}: Permission denied."
+msgstr "Nie można otworzyć {}: Brak dostępu."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Nie można otworzyć %s: Nieznany typ pliku."
+msgid "Could not open {}: Unknown file type."
+msgstr "Nie można otworzyć {}: Nieznany typ pliku."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Brak obrazów w „%s“"
+msgid "No images in '{}'"
+msgstr "Brak obrazów w „{}“"
 
 #
 # File: src/filehandler.py, line: 411
@@ -622,8 +622,8 @@ msgstr "Wpisz nową nazwę dla wybranej kolekcji. "
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Nie można zmienić nazwy na „%s“."
+msgid "Could not change the name to '{}'."
+msgstr "Nie można zmienić nazwy na „{}“."
 
 #
 # File: src/library.py, line: 275
@@ -649,25 +649,25 @@ msgstr "Korzeń"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "Umieść kolekcję „%(subcollection)s“ w kolekcji „%(supercollection)s“."
+msgstr "Umieść kolekcję „{subcollection}“ w kolekcji „{supercollection}“."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Dodaj książki do „%s“."
+msgid "Add books to '{}'."
+msgstr "Dodaj książki do „{}“."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Przenieś książki z „%(source collection)s“ do „%(destination collection)s“."
+"Przenieś książki z „{source collection}“ do „{destination collection}“."
 
 #
 # File: src/library.py, line: 492
@@ -685,8 +685,8 @@ msgstr "Usuń z biblioteki…"
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Usuń %(num)d książkę(książki) z „%(collection)s“."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Usuń {num} książkę(książki) z „{collection}“."
 
 #
 # File: src/library.py, line: 597
@@ -708,8 +708,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Usunięto %d książek z biblioteki."
+msgid "Removed {} book(s) from the library."
+msgstr "Usunięto {} książek z biblioteki."
 
 #
 # File: src/library.py, line: 769
@@ -768,8 +768,8 @@ msgstr "Otwórz zaznaczoną książkę."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d stron"
+msgid "{} pages"
+msgstr "{} stron"
 
 #
 # File: src/library.py, line: 854
@@ -793,8 +793,8 @@ msgstr "Nowa kolekcja"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Nie można dodać nowej kolekcji o nazwie „%s“."
+msgid "Could not add a new collection called '{}'."
+msgstr "Nie można dodać nowej kolekcji o nazwie „{}“."
 
 #
 # File: src/library.py, line: 910
@@ -812,8 +812,8 @@ msgstr "Dodane książki"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Dodawanie „%s“…"
+msgid "Adding '{}'..."
+msgstr "Dodawanie „{}“…"
 
 #
 # File: src/main.py, line: 666
@@ -1281,8 +1281,8 @@ msgstr "Właściwości"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d komentarze"
+msgid "{} comments"
+msgstr "{} komentarze"
 
 #
 # File: src/properties.py, line: 124
@@ -1418,8 +1418,8 @@ msgstr "Całkowita wielkość usuniętych miniatur"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Usunięta miniatura dla „%s“"
+msgid "Removed thumbnail for '{}'"
+msgstr "Usunięta miniatura dla „{}“"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/pt_BR/LC_MESSAGES/comix.po
+++ b/messages/pt_BR/LC_MESSAGES/comix.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: Marcelo Góes <vanquirius@gentoo.org>\n"
+"Last-Translator: Marcelo Gï¿½es <vanquirius@gentoo.org>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
@@ -16,16 +16,16 @@ msgstr "Sobre"
 #: src/about.py:56
 msgid "Comix is an image viewer specifically designed to handle comic books."
 msgstr ""
-"Comix é um visualizador de imagens desenhado especificamente para lidar com "
-"histórias em quadrinhos."
+"Comix ï¿½ um visualizador de imagens desenhado especificamente para lidar com "
+"histï¿½rias em quadrinhos."
 
 #: src/about.py:58
 msgid "It reads ZIP, RAR and tar archives, as well as plain image files."
-msgstr "Ele lê arquivos ZIP, RAR e tar, bem como imagens normais."
+msgstr "Ele lï¿½ arquivos ZIP, RAR e tar, bem como imagens normais."
 
 #: src/about.py:60
 msgid "Comix is licensed under the GNU General Public License."
-msgstr "Comix é licenciado pela GNU General Public License."
+msgstr "Comix ï¿½ licenciado pela GNU General Public License."
 
 #: src/about.py:83
 msgid "Developer"
@@ -33,79 +33,79 @@ msgstr "Desenvolvedor"
 
 #: src/about.py:84 src/about.py:85
 msgid "Simplified Chinese translation"
-msgstr "Tradução para chinês simplificado"
+msgstr "Traduï¿½ï¿½o para chinï¿½s simplificado"
 
 #: src/about.py:86
 msgid "Spanish translation"
-msgstr "Tradução para espanhol"
+msgstr "Traduï¿½ï¿½o para espanhol"
 
 #: src/about.py:87
 msgid "Brazilian Portuguese translation"
-msgstr "Tradução para português do Brasil"
+msgstr "Traduï¿½ï¿½o para portuguï¿½s do Brasil"
 
 #: src/about.py:88
 msgid "German translation and Nautilus thumbnailer"
-msgstr "Tradução para alemão e thumbnailer do Nautilus"
+msgstr "Traduï¿½ï¿½o para alemï¿½o e thumbnailer do Nautilus"
 
 #: src/about.py:89 src/about.py:90
 msgid "Italian translation"
-msgstr "Tradução para italiano"
+msgstr "Traduï¿½ï¿½o para italiano"
 
 #: src/about.py:91
 msgid "Dutch translation"
-msgstr "Tradução para holandês"
+msgstr "Traduï¿½ï¿½o para holandï¿½s"
 
 #: src/about.py:92 src/about.py:93
 msgid "French translation"
-msgstr "Tradução para francês"
+msgstr "Traduï¿½ï¿½o para francï¿½s"
 
 #: src/about.py:94 src/about.py:95
 msgid "Polish translation"
-msgstr "Tradução para polonês"
+msgstr "Traduï¿½ï¿½o para polonï¿½s"
 
 #: src/about.py:96
 msgid "Greek translation"
-msgstr "Tradução para grego"
+msgstr "Traduï¿½ï¿½o para grego"
 
 #: src/about.py:97
 msgid "Catalan translation"
-msgstr "Tradução para catalão"
+msgstr "Traduï¿½ï¿½o para catalï¿½o"
 
 #: src/about.py:98 src/about.py:99
 msgid "Traditional Chinese translation"
-msgstr "Tradução para chinês tradicional"
+msgstr "Traduï¿½ï¿½o para chinï¿½s tradicional"
 
 #: src/about.py:100
 msgid "Japanese translation"
-msgstr "Tradução para japonês"
+msgstr "Traduï¿½ï¿½o para japonï¿½s"
 
 #: src/about.py:101
 msgid "Hungarian translation"
-msgstr "Tradução para húngaro"
+msgstr "Traduï¿½ï¿½o para hï¿½ngaro"
 
 #: src/about.py:102
 msgid "Russian translation"
-msgstr "Tradução para russo"
+msgstr "Traduï¿½ï¿½o para russo"
 
 #: src/about.py:103
 msgid "Croatian translation"
-msgstr "Tradução para croata"
+msgstr "Traduï¿½ï¿½o para croata"
 
 #: src/about.py:104
 msgid "Korean translation"
-msgstr "Tradução para coreano"
+msgstr "Traduï¿½ï¿½o para coreano"
 
 #: src/about.py:105
 msgid "Persian translation"
-msgstr "Tradução para persa"
+msgstr "Traduï¿½ï¿½o para persa"
 
 #: src/about.py:106
 msgid "Indonesian translation"
-msgstr "Tradução para língua indonésia"
+msgstr "Traduï¿½ï¿½o para lï¿½ngua indonï¿½sia"
 
 #: src/about.py:107
 msgid "Czech translation"
-msgstr "Tradução para checo"
+msgstr "Traduï¿½ï¿½o para checo"
 
 #: src/about.py:108
 msgid "Ukrainian translation"
@@ -113,22 +113,22 @@ msgstr ""
 
 #: src/about.py:109
 msgid "Icon design"
-msgstr "Desenho dos ícones"
+msgstr "Desenho dos ï¿½cones"
 
 #: src/about.py:116
 msgid "Credits"
-msgstr "Créditos"
+msgstr "Crï¿½ditos"
 
 #: src/archive.py:66
 msgid "Could not find RAR file extractor!"
-msgstr "Não foi possível encontrar programa para extração de arquivo RAR!"
+msgstr "Nï¿½o foi possï¿½vel encontrar programa para extraï¿½ï¿½o de arquivo RAR!"
 
 #: src/archive.py:68
 msgid ""
 "You need either the <i>rar</i> or the <i>unrar</i> program installed in "
 "order to read RAR (.cbr) files."
 msgstr ""
-"Você precisa do programa <i>rar</i> ou <i>unrar</i> instalado para poder ler "
+"Vocï¿½ precisa do programa <i>rar</i> ou <i>unrar</i> instalado para poder ler "
 "arquivos RAR (.cbr)."
 
 #: src/archive.py:306
@@ -171,7 +171,7 @@ msgstr "Limpar todos os favoritos?"
 msgid ""
 "All stored bookmarks will be removed. Are you sure that you want to continue?"
 msgstr ""
-"Todos os favoritos gravados serão removidos. Tem certeza de que deseja "
+"Todos os favoritos gravados serï¿½o removidos. Tem certeza de que deseja "
 "continuar?"
 
 #: src/bookmark.py:230
@@ -184,16 +184,16 @@ msgstr "Nome"
 
 #: src/bookmark.py:257
 msgid "Page"
-msgstr "Página"
+msgstr "Pï¿½gina"
 
 #: src/comment.py:16 src/preferences.py:301
 msgid "Comments"
-msgstr "Comentários"
+msgstr "Comentï¿½rios"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Não foi possível ler %s"
+msgid "Could not read {}"
+msgstr "Nï¿½o foi possï¿½vel ler {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -207,11 +207,11 @@ msgid ""
 "remove these files in order to save some disk space. Do you want these files "
 "to be removed for you now?"
 msgstr ""
-"Alguns arquivos antigos (que eram usados para salvar preferências, a "
-"biblioteca, favoritos e outros, em versões antigas do Comix) foram "
-"encontrados em seu computador. Se você não planeja usar as versões antigas "
-"do Comix novamente, você deve remover esses arquivos para economizar espaço "
-"em disco. Deseja que esses arquivos sejam removidos para você agora?"
+"Alguns arquivos antigos (que eram usados para salvar preferï¿½ncias, a "
+"biblioteca, favoritos e outros, em versï¿½es antigas do Comix) foram "
+"encontrados em seu computador. Se vocï¿½ nï¿½o planeja usar as versï¿½es antigas "
+"do Comix novamente, vocï¿½ deve remover esses arquivos para economizar espaï¿½o "
+"em disco. Deseja que esses arquivos sejam removidos para vocï¿½ agora?"
 
 #: src/edit.py:29
 msgid "Edit archive"
@@ -231,15 +231,15 @@ msgstr "Outros arquivos"
 
 #: src/edit.py:101
 msgid "The new archive could not be saved!"
-msgstr "O novo arquivo não pôde ser gravado!"
+msgstr "O novo arquivo nï¿½o pï¿½de ser gravado!"
 
 #: src/edit.py:103
 msgid "The original files have not been removed."
-msgstr "Os arquivos originais não foram removidos."
+msgstr "Os arquivos originais nï¿½o foram removidos."
 
 #: src/edit.py:117
 msgid "Archives are stored as ZIP files."
-msgstr "Arquivos são gravados em formato ZIP."
+msgstr "Arquivos sï¿½o gravados em formato ZIP."
 
 #: src/edit.py:170 src/edit.py:288
 msgid "Remove from archive"
@@ -250,8 +250,8 @@ msgid ""
 "Please note that the only files that are automatically added to this list "
 "are those files in archives that Comix recognizes as comments."
 msgstr ""
-"Por favor, note que os únicos arquivos adicionados automaticamente nesta "
-"lista são os arquivos que o Comix reconhece como comentários."
+"Por favor, note que os ï¿½nicos arquivos adicionados automaticamente nesta "
+"lista sï¿½o os arquivos que o Comix reconhece como comentï¿½rios."
 
 #: src/edit.py:273
 msgid "Size"
@@ -263,7 +263,7 @@ msgstr "Melhorar imagem"
 
 #: src/enhance.py:52
 msgid "Defaults"
-msgstr "Padrões"
+msgstr "Padrï¿½es"
 
 #: src/enhance.py:79
 msgid "Brightness"
@@ -275,7 +275,7 @@ msgstr "Contraste"
 
 #: src/enhance.py:101
 msgid "Saturation"
-msgstr "Saturação"
+msgstr "Saturaï¿½ï¿½o"
 
 #: src/enhance.py:112
 msgid "Sharpness"
@@ -323,12 +323,12 @@ msgstr "Arquivos tar"
 
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Um arquivo com o nome '%s' já existe. Deseja substituí-lo?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Um arquivo com o nome '{}' jï¿½ existe. Deseja substituï¿½-lo?"
 
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
-msgstr "A substituição sobreescreverá seu conteúdo."
+msgstr "A substituiï¿½ï¿½o sobreescreverï¿½ seu conteï¿½do."
 
 #: src/filechooser.py:187 src/filechooser.py:304
 msgid "All images"
@@ -344,32 +344,32 @@ msgstr "Imagens PNG"
 
 #: src/filechooser.py:231
 msgid "Automatically add the books to this collection"
-msgstr "Adicionar livros a esta coleção automaticamente"
+msgstr "Adicionar livros a esta coleï¿½ï¿½o automaticamente"
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Impossível abrir %s: É um diretório."
+msgid "Could not open {}: Is a directory."
+msgstr "Impossï¿½vel abrir {}: ï¿½ um diretï¿½rio."
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Impossível abrir %s: Arquivo não existe."
+msgid "Could not open {}: No such file."
+msgstr "Impossï¿½vel abrir {}: Arquivo nï¿½o existe."
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Impossível abrir %s: Permissão negada."
+msgid "Could not open {}: Permission denied."
+msgstr "Impossï¿½vel abrir {}: Permissï¿½o negada."
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Impossível abrir %s: Tipo de arquivo desconhecido."
+msgid "Could not open {}: Unknown file type."
+msgstr "Impossï¿½vel abrir {}: Tipo de arquivo desconhecido."
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Não há imagens em '%s'"
+msgid "No images in '{}'"
+msgstr "Nï¿½o hï¿½ imagens em '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -377,7 +377,7 @@ msgstr "Tipo de arquivo desconhecido"
 
 #: src/librarybackend.py:271 src/librarybackend.py:273
 msgid "(Copy)"
-msgstr "(Cópia)"
+msgstr "(Cï¿½pia)"
 
 #: src/library.py:38
 msgid "Library"
@@ -389,11 +389,11 @@ msgstr "Renomear..."
 
 #: src/library.py:152
 msgid "Duplicate collection"
-msgstr "Coleção duplicada"
+msgstr "Coleï¿½ï¿½o duplicada"
 
 #: src/library.py:154
 msgid "Remove collection..."
-msgstr "Remover coleção..."
+msgstr "Remover coleï¿½ï¿½o..."
 
 #: src/library.py:202
 msgid "All books"
@@ -401,36 +401,36 @@ msgstr "Todos os livros"
 
 #: src/library.py:231
 msgid "Remove collection from the library?"
-msgstr "Remover coleção da biblioteca?"
+msgstr "Remover coleï¿½ï¿½o da biblioteca?"
 
 #: src/library.py:233
 msgid ""
 "The selected collection will be removed from the library (but the books and "
 "subcollections in it will remain). Are you sure that you want to continue?"
 msgstr ""
-"A coleção selecionada será removida da biblioteca (mas os livros e as sub-"
-"coleção dentro dela permanecerão). Tem certeza de que deseja continuar?"
+"A coleï¿½ï¿½o selecionada serï¿½ removida da biblioteca (mas os livros e as sub-"
+"coleï¿½ï¿½o dentro dela permanecerï¿½o). Tem certeza de que deseja continuar?"
 
 #: src/library.py:251
 msgid "Rename collection?"
-msgstr "Renomear coleção?"
+msgstr "Renomear coleï¿½ï¿½o?"
 
 #: src/library.py:253
 msgid "Please enter a new name for the selected collection."
-msgstr "Por favor, digite um novo nome para a coleção selecionada."
+msgstr "Por favor, digite um novo nome para a coleï¿½ï¿½o selecionada."
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Impossível renomear para '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Impossï¿½vel renomear para '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
-msgstr "Uma coleção com esse nome já existe."
+msgstr "Uma coleï¿½ï¿½o com esse nome jï¿½ existe."
 
 #: src/library.py:285
 msgid "Could not duplicate collection."
-msgstr "Impossível duplicar coleção."
+msgstr "Impossï¿½vel duplicar coleï¿½ï¿½o."
 
 #: src/library.py:382
 msgid "Root"
@@ -439,26 +439,26 @@ msgstr "Raiz"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Coloque a coleção '%(subcollection)s' na coleção '%(supercollection)s'."
+"Coloque a coleï¿½ï¿½o '{subcollection}' na coleï¿½ï¿½o '{supercollection}'."
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Adicionar livros para '%s'."
+msgid "Add books to '{}'."
+msgstr "Adicionar livros para '{}'."
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Mover livros de '%(source collection)s' para '%(destination collection)s'."
+"Mover livros de '{source collection}' para '{destination collection}'."
 
 #: src/library.py:493
 msgid "Remove from this collection"
-msgstr "Remover desta coleção"
+msgstr "Remover desta coleï¿½ï¿½o"
 
 #: src/library.py:496
 msgid "Remove from the library..."
@@ -466,8 +466,8 @@ msgstr "Remover da biblioteca..."
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Foram removidos %(num)d livro(s) de '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Foram removidos {num} livro(s) de '{collection}'."
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -478,13 +478,13 @@ msgid ""
 "The selected books will be removed from the library (but the original files "
 "will be untouched). Are you sure that you want to continue?"
 msgstr ""
-"Os livros selecionados serão removidos da biblioteca (mas os arquivos "
-"originais não serão modificados). Tem certeza de que deseja continuar?"
+"Os livros selecionados serï¿½o removidos da biblioteca (mas os arquivos "
+"originais nï¿½o serï¿½o modificados). Tem certeza de que deseja continuar?"
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Foram removidos %d livro(s) da biblioteca."
+msgid "Removed {} book(s) from the library."
+msgstr "Foram removidos {} livro(s) da biblioteca."
 
 #: src/library.py:770
 msgid "Search"
@@ -495,8 +495,8 @@ msgid ""
 "Display only those books that have the specified text string in their full "
 "path. The search is not case sensitive."
 msgstr ""
-"Mostrar só os livros que têm o texto especificado no seu caminho completo. A "
-"busca não é sensível a maiúscula e minúscula."
+"Mostrar sï¿½ os livros que tï¿½m o texto especificado no seu caminho completo. A "
+"busca nï¿½o ï¿½ sensï¿½vel a maiï¿½scula e minï¿½scula."
 
 #: src/library.py:777
 msgid "Cover size"
@@ -508,15 +508,15 @@ msgstr "Adicionar livros"
 
 #: src/library.py:794
 msgid "Add more books to the library."
-msgstr "Adicionar mais livros à biblioteca."
+msgstr "Adicionar mais livros ï¿½ biblioteca."
 
 #: src/library.py:796
 msgid "Add collection"
-msgstr "Adicionar coleção"
+msgstr "Adicionar coleï¿½ï¿½o"
 
 #: src/library.py:801
 msgid "Add a new empty collection."
-msgstr "Adicionar nova coleção vazia."
+msgstr "Adicionar nova coleï¿½ï¿½o vazia."
 
 #: src/library.py:807
 msgid "Open the selected book."
@@ -524,25 +524,25 @@ msgstr "Abrir o livro selecionado."
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d páginas"
+msgid "{} pages"
+msgstr "{} pï¿½ginas"
 
 #: src/library.py:855
 msgid "Add new collection?"
-msgstr "Adicionar nova coleção?"
+msgstr "Adicionar nova coleï¿½ï¿½o?"
 
 #: src/library.py:857
 msgid "Please enter a name for the new collection."
-msgstr "Por favor, digite o nome da nova coleção."
+msgstr "Por favor, digite o nome da nova coleï¿½ï¿½o."
 
 #: src/library.py:863
 msgid "New collection"
-msgstr "Nova coleção"
+msgstr "Nova coleï¿½ï¿½o"
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Impossível adicionar uma nova coleção chamada '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Impossï¿½vel adicionar uma nova coleï¿½ï¿½o chamada '{}'."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -554,16 +554,16 @@ msgstr "Livros adicionados"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Adicionando '%s'..."
+msgid "Adding '{}'..."
+msgstr "Adicionando '{}'..."
 
 #: src/main.py:704
 msgid "SLIDESHOW"
-msgstr "Apresentação de slides"
+msgstr "Apresentaï¿½ï¿½o de slides"
 
 #: src/preferences.py:82
 msgid "Preferences"
-msgstr "Preferências"
+msgstr "Preferï¿½ncias"
 
 #: src/preferences.py:97
 msgid "Background"
@@ -579,12 +579,12 @@ msgstr "Sempre usar essa cor como cor de fundo."
 
 #: src/preferences.py:106
 msgid "Use dynamic background colour."
-msgstr "Usar cor de fundo dinâmica."
+msgstr "Usar cor de fundo dinï¿½mica."
 
 #: src/preferences.py:110
 msgid "Automatically pick a background colour that fits the viewed image."
 msgstr ""
-"Escolher uma cor de fundo compatível com a imagem visualizada "
+"Escolher uma cor de fundo compatï¿½vel com a imagem visualizada "
 "automaticamente."
 
 #: src/preferences.py:113
@@ -597,7 +597,7 @@ msgstr "Tamanho da miniatura (em pixels)"
 
 #: src/preferences.py:121
 msgid "Show page numbers on thumbnails."
-msgstr "Mostrar números de página nas miniaturas."
+msgstr "Mostrar nï¿½meros de pï¿½gina nas miniaturas."
 
 #: src/preferences.py:128
 msgid "Magnifying Glass"
@@ -612,7 +612,7 @@ msgid ""
 "Set the size of the magnifying glass. It is a square with a side of this "
 "many pixels."
 msgstr ""
-"Ajustar o tamanho da lente de aumento. É um quadrado com esse tamanho de "
+"Ajustar o tamanho da lente de aumento. ï¿½ um quadrado com esse tamanho de "
 "pixels."
 
 #: src/preferences.py:137
@@ -637,13 +637,13 @@ msgid ""
 "current zoom mode requests it. If this preference is unset, images are never "
 "scaled to be larger than their original size."
 msgstr ""
-"Esticar imagens para um tamanho que é maior que seu tamanho original se o "
-"modo de zoom atual pedir. Se esta preferência não estiver marcada, as "
-"imagens nunca serão vistas maior que seu tamanho original."
+"Esticar imagens para um tamanho que ï¿½ maior que seu tamanho original se o "
+"modo de zoom atual pedir. Se esta preferï¿½ncia nï¿½o estiver marcada, as "
+"imagens nunca serï¿½o vistas maior que seu tamanho original."
 
 #: src/preferences.py:155
 msgid "Transparency"
-msgstr "Transparência"
+msgstr "Transparï¿½ncia"
 
 #: src/preferences.py:157
 msgid "Use checkered background for transparent images."
@@ -655,11 +655,11 @@ msgid ""
 "is unset, the background is plain white instead."
 msgstr ""
 "Usar fundo quadriculado cinza para imagens transparentes. Se esta "
-"preferência não estiver marcada, o fundo usado é branco."
+"preferï¿½ncia nï¿½o estiver marcada, o fundo usado ï¿½ branco."
 
 #: src/preferences.py:165
 msgid "Appearance"
-msgstr "Aparência"
+msgstr "Aparï¿½ncia"
 
 #: src/preferences.py:171
 msgid "Scroll"
@@ -667,7 +667,7 @@ msgstr "Rolagem"
 
 #: src/preferences.py:173
 msgid "Use smart space key scrolling."
-msgstr "Usar rolagem inteligente com tecla de espaço."
+msgstr "Usar rolagem inteligente com tecla de espaï¿½o."
 
 #: src/preferences.py:178
 msgid ""
@@ -676,14 +676,14 @@ msgid ""
 "also scrolls sideways and so tries to follow the natural reading order of "
 "the comic book."
 msgstr ""
-"Usar rolagem inteligente com telca de espaço. Normalmente, a tecla de espaço "
-"só rola para baixo (ou para cima quando shift é apertado). No entanto, com "
-"esta perferência também rola para os lados e tenta seguir a ordem natural de "
-"leitura de uma história em quadrinhos."
+"Usar rolagem inteligente com telca de espaï¿½o. Normalmente, a tecla de espaï¿½o "
+"sï¿½ rola para baixo (ou para cima quando shift ï¿½ apertado). No entanto, com "
+"esta perferï¿½ncia tambï¿½m rola para os lados e tenta seguir a ordem natural de "
+"leitura de uma histï¿½ria em quadrinhos."
 
 #: src/preferences.py:182
 msgid "Flip pages when scrolling off the edges of the page."
-msgstr "Virar páginas quando rolar para fora da borda da página."
+msgstr "Virar pï¿½ginas quando rolar para fora da borda da pï¿½gina."
 
 #: src/preferences.py:187
 msgid ""
@@ -691,28 +691,28 @@ msgid ""
 "arrow keys. It takes three consecutive \"steps\" with the scroll wheel or "
 "the arrow keys for the pages to be flipped."
 msgstr ""
-"Virar páginas quando rolar \"para fora da página\" com a roda de roladagem "
-"ou teclas de seta. São necessários três \"passos\" consecutivos com a roda "
-"de rolagem ou teclas de seta para que as páginas sejam viradas."
+"Virar pï¿½ginas quando rolar \"para fora da pï¿½gina\" com a roda de roladagem "
+"ou teclas de seta. Sï¿½o necessï¿½rios trï¿½s \"passos\" consecutivos com a roda "
+"de rolagem ou teclas de seta para que as pï¿½ginas sejam viradas."
 
 #: src/preferences.py:190 src/ui.py:298
 msgid "Double page mode"
-msgstr "Modo de página dupla"
+msgstr "Modo de pï¿½gina dupla"
 
 #: src/preferences.py:192
 msgid "Flip two pages in double page mode."
-msgstr "Virar duas páginas em modo de página dupla."
+msgstr "Virar duas pï¿½ginas em modo de pï¿½gina dupla."
 
 #: src/preferences.py:197
 msgid ""
 "Flip two pages, instead of one, each time we flip pages in double page mode."
 msgstr ""
-"Virar duas páginas, ao invés de uma, cada vez que virar página em modo de "
-"página dupla."
+"Virar duas pï¿½ginas, ao invï¿½s de uma, cada vez que virar pï¿½gina em modo de "
+"pï¿½gina dupla."
 
 #: src/preferences.py:200
 msgid "Show only one wide image in double page mode."
-msgstr "Mostrar só uma imagem larga em modo de página dupl.a"
+msgstr "Mostrar sï¿½ uma imagem larga em modo de pï¿½gina dupl.a"
 
 #: src/preferences.py:206
 msgid ""
@@ -720,9 +720,9 @@ msgid ""
 "height. The result of this is that scans that span two pages are displayed "
 "properly (i.e. alone) also in double page mode."
 msgstr ""
-"Mostra só uma imagem em modo de página dupla, se a largura da imagem exceder "
-"sua altura. O resultado disto é que scans que passem de duas páginas são "
-"mostrados adequadamente (isto é, sozinhos) também em modo de página dupla."
+"Mostra sï¿½ uma imagem em modo de pï¿½gina dupla, se a largura da imagem exceder "
+"sua altura. O resultado disto ï¿½ que scans que passem de duas pï¿½ginas sï¿½o "
+"mostrados adequadamente (isto ï¿½, sozinhos) tambï¿½m em modo de pï¿½gina dupla."
 
 #: src/preferences.py:209
 msgid "Files"
@@ -730,19 +730,19 @@ msgstr "Arquivos"
 
 #: src/preferences.py:211
 msgid "Automatically open the next archive."
-msgstr "Abrir o próximo arquivo automaticamente."
+msgstr "Abrir o prï¿½ximo arquivo automaticamente."
 
 #: src/preferences.py:216
 msgid ""
 "Automatically open the next archive in the directory when flipping past the "
 "last page, or the previous archive when flipping past the first page."
 msgstr ""
-"Abre o próximo arquivo do diretório automaticamente quando virar após a "
-"última página, ou o arquivo anterior quando virar antes da primeira página."
+"Abre o prï¿½ximo arquivo do diretï¿½rio automaticamente quando virar apï¿½s a "
+"ï¿½ltima pï¿½gina, ou o arquivo anterior quando virar antes da primeira pï¿½gina."
 
 #: src/preferences.py:219
 msgid "Automatically open the last viewed file on startup."
-msgstr "Abrir o último arquivo visto automaticamente quando abrir."
+msgstr "Abrir o ï¿½ltimo arquivo visto automaticamente quando abrir."
 
 #: src/preferences.py:224
 msgid ""
@@ -750,18 +750,18 @@ msgid ""
 "closed."
 msgstr ""
 "Abre, quando inicia, o arquivo que estava aberto quando o Comix foi fechado "
-"da última vez."
+"da ï¿½ltima vez."
 
 #: src/preferences.py:227
 msgid "Store information about recently opened files."
-msgstr "Guarda informações sobre arquivos abertos recentemente."
+msgstr "Guarda informaï¿½ï¿½es sobre arquivos abertos recentemente."
 
 #: src/preferences.py:232
 msgid ""
 "Add information about all files opened from within Comix to the shared "
 "recent files list."
 msgstr ""
-"Adicionar informações sobre todos os arquivos abertos dentro do Comix para a "
+"Adicionar informaï¿½ï¿½es sobre todos os arquivos abertos dentro do Comix para a "
 "lista de arquivos compartilhados recentes."
 
 #: src/preferences.py:235
@@ -774,8 +774,8 @@ msgid ""
 "specification. These thumbnails are shared by many other applications, such "
 "as most file managers."
 msgstr ""
-"Guarda miniaturas de arquivos abertos de acordo com a especificação do "
-"freedesktop.org. Essas miniaturas são compartilhadas por vários outros "
+"Guarda miniaturas de arquivos abertos de acordo com a especificaï¿½ï¿½o do "
+"freedesktop.org. Essas miniaturas sï¿½o compartilhadas por vï¿½rios outros "
 "aplicativos, como a maior parte dos gerenciadores de arquivos."
 
 #: src/preferences.py:243
@@ -784,7 +784,7 @@ msgstr "Cache"
 
 #: src/preferences.py:244
 msgid "Use a cache to speed up browsing."
-msgstr "Usar um cache para aumentar velocidade de navegação."
+msgstr "Usar um cache para aumentar velocidade de navegaï¿½ï¿½o."
 
 #: src/preferences.py:248
 msgid ""
@@ -793,10 +793,10 @@ msgid ""
 "recommended that you have this preference set, unless you are running short "
 "on free RAM."
 msgstr ""
-"Faz cache das imagens que estão próximas a imagem vista atualmente para "
-"acelerar a navegação. Já que a melhoria de velocidade é grande, é "
-"recomendável ter esta preferência marcada, a menos que você esteja com pouca "
-"memória RAM."
+"Faz cache das imagens que estï¿½o prï¿½ximas a imagem vista atualmente para "
+"acelerar a navegaï¿½ï¿½o. Jï¿½ que a melhoria de velocidade ï¿½ grande, ï¿½ "
+"recomendï¿½vel ter esta preferï¿½ncia marcada, a menos que vocï¿½ esteja com pouca "
+"memï¿½ria RAM."
 
 #: src/preferences.py:250
 msgid "Behaviour"
@@ -804,23 +804,23 @@ msgstr "Comportamento"
 
 #: src/preferences.py:256
 msgid "Default modes"
-msgstr "Modos padrão"
+msgstr "Modos padrï¿½o"
 
 #: src/preferences.py:258
 msgid "Use double page mode by default."
-msgstr "Usar página dupla por padrão."
+msgstr "Usar pï¿½gina dupla por padrï¿½o."
 
 #: src/preferences.py:263
 msgid "Use fullscreen by default."
-msgstr "Usar tela cheia por padrão."
+msgstr "Usar tela cheia por padrï¿½o."
 
 #: src/preferences.py:268
 msgid "Use manga mode by default."
-msgstr "Usar modo mangá por padrão."
+msgstr "Usar modo mangï¿½ por padrï¿½o."
 
 #: src/preferences.py:273
 msgid "Default zoom mode"
-msgstr "Modo de zoom padrão"
+msgstr "Modo de zoom padrï¿½o"
 
 #: src/preferences.py:275 src/ui.py:290
 msgid "Best fit mode"
@@ -844,19 +844,19 @@ msgstr "Tela cheia"
 
 #: src/preferences.py:286
 msgid "Automatically hide all toolbars in fullscreen."
-msgstr "Esconder todas as barras de ferramenta por padrão em tela cheia."
+msgstr "Esconder todas as barras de ferramenta por padrï¿½o em tela cheia."
 
 #: src/preferences.py:292
 msgid "Slideshow"
-msgstr "Apresentação de slides"
+msgstr "Apresentaï¿½ï¿½o de slides"
 
 #: src/preferences.py:293
 msgid "Slideshow delay (in seconds)"
-msgstr "Espera da apresentação de slides (em segundos)"
+msgstr "Espera da apresentaï¿½ï¿½o de slides (em segundos)"
 
 #: src/preferences.py:302
 msgid "Comment extensions"
-msgstr "Comentar extensões"
+msgstr "Comentar extensï¿½es"
 
 #: src/preferences.py:308
 msgid ""
@@ -864,7 +864,7 @@ msgid ""
 "as comments."
 msgstr ""
 "Tratar todos os arquivos avulsos dentro de arquivos, incluindo os que tem "
-"terminação de arquivo, como comentários."
+"terminaï¿½ï¿½o de arquivo, como comentï¿½rios."
 
 #: src/preferences.py:311
 msgid "Rotation"
@@ -890,8 +890,8 @@ msgstr "Propriedades"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d comentários"
+msgid "{} comments"
+msgstr "{} comentï¿½rios"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -907,7 +907,7 @@ msgstr "Modificado"
 
 #: src/properties.py:135 src/properties.py:169
 msgid "Permissions"
-msgstr "Permissões"
+msgstr "Permissï¿½es"
 
 #: src/properties.py:136 src/properties.py:170
 msgid "Owner"
@@ -923,7 +923,7 @@ msgstr "Imagem"
 
 #: src/thumbremover.py:24
 msgid "Thumbnail maintenance"
-msgstr "Manutenção de miniatura"
+msgstr "Manutenï¿½ï¿½o de miniatura"
 
 #: src/thumbremover.py:26
 msgid "Cleanup"
@@ -941,20 +941,20 @@ msgid ""
 "files have been removed - wasting space. This dialog can cleanup your stored "
 "thumbnails by removing orphaned and outdated thumbnails."
 msgstr ""
-"Miniaturas para arquivos avulsos (como arquivos de imagem e histórias em "
-"quadrinhos) são guardadas em seu diretório de usuário. Muitos aplicativos "
+"Miniaturas para arquivos avulsos (como arquivos de imagem e histï¿½rias em "
+"quadrinhos) sï¿½o guardadas em seu diretï¿½rio de usuï¿½rio. Muitos aplicativos "
 "diferentes usam e criam essas miniaturas, mas algumas vezes as miniaturas "
 "permanecem apesar de os arquivos originais terem sido removidos - "
-"despediçando espaço. Este diálogo pode limpar miniaturas ao remover "
-"minaturas órfãs e ultrapassadas."
+"despediï¿½ando espaï¿½o. Este diï¿½logo pode limpar miniaturas ao remover "
+"minaturas ï¿½rfï¿½s e ultrapassadas."
 
 #: src/thumbremover.py:60
 msgid "Thumbnail directory"
-msgstr "Diretório de miniaturas"
+msgstr "Diretï¿½rio de miniaturas"
 
 #: src/thumbremover.py:67
 msgid "Total number of thumbnails"
-msgstr "Número total de miniaturas"
+msgstr "Nï¿½mero total de miniaturas"
 
 #: src/thumbremover.py:70 src/thumbremover.py:77
 msgid "Calculating..."
@@ -966,7 +966,7 @@ msgstr "Tamanho total das miniaturas"
 
 #: src/thumbremover.py:82
 msgid "Do you want to cleanup orphaned and outdated thumbnails now?"
-msgstr "Deseja limpar miniaturas órfãs ou ultrapassadas agora?"
+msgstr "Deseja limpar miniaturas ï¿½rfï¿½s ou ultrapassadas agora?"
 
 #: src/thumbremover.py:118
 msgid "Removing thumbnails"
@@ -974,7 +974,7 @@ msgstr "Removendo miniaturas"
 
 #: src/thumbremover.py:137
 msgid "Number of removed thumbnails"
-msgstr "Número de miniaturas removidas"
+msgstr "Nï¿½mero de miniaturas removidas"
 
 #: src/thumbremover.py:144
 msgid "Total size of removed thumbnails"
@@ -982,24 +982,24 @@ msgstr "Tamanho total das miniaturas removidas"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Removida a miniatura de '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Removida a miniatura de '{}'"
 
 #: src/ui.py:34
 msgid "_Next page"
-msgstr "_Próxima página"
+msgstr "_Prï¿½xima pï¿½gina"
 
 #: src/ui.py:36
 msgid "_Previous page"
-msgstr "Pá_gina anterior"
+msgstr "Pï¿½_gina anterior"
 
 #: src/ui.py:38
 msgid "_First page"
-msgstr "P_rimeira página"
+msgstr "P_rimeira pï¿½gina"
 
 #: src/ui.py:40
 msgid "_Last page"
-msgstr "_Última página"
+msgstr "_ï¿½ltima pï¿½gina"
 
 #: src/ui.py:42
 msgid "_Zoom in"
@@ -1023,15 +1023,15 @@ msgstr "_Sair"
 
 #: src/ui.py:52
 msgid "_Rotate 90 degrees CW"
-msgstr "Ro_tação de 90 graus horários"
+msgstr "Ro_taï¿½ï¿½o de 90 graus horï¿½rios"
 
 #: src/ui.py:54
 msgid "Rotate 180 de_grees"
-msgstr "Rotação de 180 graus"
+msgstr "Rotaï¿½ï¿½o de 180 graus"
 
 #: src/ui.py:56
 msgid "Rotat_e 90 degrees CCW"
-msgstr "Ro_tação de 90 graus anti-horários"
+msgstr "Ro_taï¿½ï¿½o de 90 graus anti-horï¿½rios"
 
 #: src/ui.py:58
 msgid "Fli_p horizontally"
@@ -1087,7 +1087,7 @@ msgstr "Tela cheia"
 
 #: src/ui.py:77
 msgid "_Double page mode"
-msgstr "Modo de página dupla"
+msgstr "Modo de pï¿½gina dupla"
 
 #: src/ui.py:79
 msgid "_Toolbar"
@@ -1115,15 +1115,15 @@ msgstr "Esconder todos"
 
 #: src/ui.py:91
 msgid "_Manga mode"
-msgstr "Modo mangá"
+msgstr "Modo mangï¿½"
 
 #: src/ui.py:93
 msgid "_Keep transformation"
-msgstr "Manter transformação"
+msgstr "Manter transformaï¿½ï¿½o"
 
 #: src/ui.py:95
 msgid "Run _slideshow"
-msgstr "Rodar apresentação de slides"
+msgstr "Rodar apresentaï¿½ï¿½o de slides"
 
 #: src/ui.py:97
 msgid "Magnifying _glass"
@@ -1151,7 +1151,7 @@ msgstr "Sobre"
 
 #: src/ui.py:117
 msgid "_View comments..."
-msgstr "Ver comentários..."
+msgstr "Ver comentï¿½rios..."
 
 #: src/ui.py:119
 msgid "_Edit archive..."
@@ -1171,11 +1171,11 @@ msgstr "Melhorar imagem..."
 
 #: src/ui.py:128
 msgid "_Thumbnail maintenance..."
-msgstr "Manutenção de miniaturas..."
+msgstr "Manutenï¿½ï¿½o de miniaturas..."
 
 #: src/ui.py:130
 msgid "Pr_eferences"
-msgstr "Preferências"
+msgstr "Preferï¿½ncias"
 
 #: src/ui.py:134
 msgid "_Library..."
@@ -1183,23 +1183,23 @@ msgstr "Biblioteca..."
 
 #: src/ui.py:284
 msgid "First page"
-msgstr "Primeira página"
+msgstr "Primeira pï¿½gina"
 
 #: src/ui.py:286
 msgid "Previous page"
-msgstr "Página anterior"
+msgstr "Pï¿½gina anterior"
 
 #: src/ui.py:287
 msgid "Next page"
-msgstr "Próxima página"
+msgstr "Prï¿½xima pï¿½gina"
 
 #: src/ui.py:288
 msgid "Last page"
-msgstr "Última página"
+msgstr "ï¿½ltima pï¿½gina"
 
 #: src/ui.py:299
 msgid "Manga mode"
-msgstr "Modo mangá"
+msgstr "Modo mangï¿½"
 
 #: src/ui.py:300
 msgid "Magnifying glass"

--- a/messages/pt_BR/LC_MESSAGES/comix.po
+++ b/messages/pt_BR/LC_MESSAGES/comix.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: Marcelo G�es <vanquirius@gentoo.org>\n"
+"Last-Translator: Marcelo Góes <vanquirius@gentoo.org>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
@@ -16,16 +16,16 @@ msgstr "Sobre"
 #: src/about.py:56
 msgid "Comix is an image viewer specifically designed to handle comic books."
 msgstr ""
-"Comix � um visualizador de imagens desenhado especificamente para lidar com "
-"hist�rias em quadrinhos."
+"Comix é um visualizador de imagens desenhado especificamente para lidar com "
+"histórias em quadrinhos."
 
 #: src/about.py:58
 msgid "It reads ZIP, RAR and tar archives, as well as plain image files."
-msgstr "Ele l� arquivos ZIP, RAR e tar, bem como imagens normais."
+msgstr "Ele lê arquivos ZIP, RAR e tar, bem como imagens normais."
 
 #: src/about.py:60
 msgid "Comix is licensed under the GNU General Public License."
-msgstr "Comix � licenciado pela GNU General Public License."
+msgstr "Comix é licenciado pela GNU General Public License."
 
 #: src/about.py:83
 msgid "Developer"
@@ -33,79 +33,79 @@ msgstr "Desenvolvedor"
 
 #: src/about.py:84 src/about.py:85
 msgid "Simplified Chinese translation"
-msgstr "Tradu��o para chin�s simplificado"
+msgstr "Tradução para chinês simplificado"
 
 #: src/about.py:86
 msgid "Spanish translation"
-msgstr "Tradu��o para espanhol"
+msgstr "Tradução para espanhol"
 
 #: src/about.py:87
 msgid "Brazilian Portuguese translation"
-msgstr "Tradu��o para portugu�s do Brasil"
+msgstr "Tradução para português do Brasil"
 
 #: src/about.py:88
 msgid "German translation and Nautilus thumbnailer"
-msgstr "Tradu��o para alem�o e thumbnailer do Nautilus"
+msgstr "Tradução para alemão e thumbnailer do Nautilus"
 
 #: src/about.py:89 src/about.py:90
 msgid "Italian translation"
-msgstr "Tradu��o para italiano"
+msgstr "Tradução para italiano"
 
 #: src/about.py:91
 msgid "Dutch translation"
-msgstr "Tradu��o para holand�s"
+msgstr "Tradução para holandês"
 
 #: src/about.py:92 src/about.py:93
 msgid "French translation"
-msgstr "Tradu��o para franc�s"
+msgstr "Tradução para francês"
 
 #: src/about.py:94 src/about.py:95
 msgid "Polish translation"
-msgstr "Tradu��o para polon�s"
+msgstr "Tradução para polonês"
 
 #: src/about.py:96
 msgid "Greek translation"
-msgstr "Tradu��o para grego"
+msgstr "Tradução para grego"
 
 #: src/about.py:97
 msgid "Catalan translation"
-msgstr "Tradu��o para catal�o"
+msgstr "Tradução para catalão"
 
 #: src/about.py:98 src/about.py:99
 msgid "Traditional Chinese translation"
-msgstr "Tradu��o para chin�s tradicional"
+msgstr "Tradução para chinês tradicional"
 
 #: src/about.py:100
 msgid "Japanese translation"
-msgstr "Tradu��o para japon�s"
+msgstr "Tradução para japonês"
 
 #: src/about.py:101
 msgid "Hungarian translation"
-msgstr "Tradu��o para h�ngaro"
+msgstr "Tradução para húngaro"
 
 #: src/about.py:102
 msgid "Russian translation"
-msgstr "Tradu��o para russo"
+msgstr "Tradução para russo"
 
 #: src/about.py:103
 msgid "Croatian translation"
-msgstr "Tradu��o para croata"
+msgstr "Tradução para croata"
 
 #: src/about.py:104
 msgid "Korean translation"
-msgstr "Tradu��o para coreano"
+msgstr "Tradução para coreano"
 
 #: src/about.py:105
 msgid "Persian translation"
-msgstr "Tradu��o para persa"
+msgstr "Tradução para persa"
 
 #: src/about.py:106
 msgid "Indonesian translation"
-msgstr "Tradu��o para l�ngua indon�sia"
+msgstr "Tradução para língua indonésia"
 
 #: src/about.py:107
 msgid "Czech translation"
-msgstr "Tradu��o para checo"
+msgstr "Tradução para checo"
 
 #: src/about.py:108
 msgid "Ukrainian translation"
@@ -113,22 +113,22 @@ msgstr ""
 
 #: src/about.py:109
 msgid "Icon design"
-msgstr "Desenho dos �cones"
+msgstr "Desenho dos ícones"
 
 #: src/about.py:116
 msgid "Credits"
-msgstr "Cr�ditos"
+msgstr "Créditos"
 
 #: src/archive.py:66
 msgid "Could not find RAR file extractor!"
-msgstr "N�o foi poss�vel encontrar programa para extra��o de arquivo RAR!"
+msgstr "Não foi possível encontrar programa para extração de arquivo RAR!"
 
 #: src/archive.py:68
 msgid ""
 "You need either the <i>rar</i> or the <i>unrar</i> program installed in "
 "order to read RAR (.cbr) files."
 msgstr ""
-"Voc� precisa do programa <i>rar</i> ou <i>unrar</i> instalado para poder ler "
+"Você precisa do programa <i>rar</i> ou <i>unrar</i> instalado para poder ler "
 "arquivos RAR (.cbr)."
 
 #: src/archive.py:306
@@ -171,7 +171,7 @@ msgstr "Limpar todos os favoritos?"
 msgid ""
 "All stored bookmarks will be removed. Are you sure that you want to continue?"
 msgstr ""
-"Todos os favoritos gravados ser�o removidos. Tem certeza de que deseja "
+"Todos os favoritos gravados serão removidos. Tem certeza de que deseja "
 "continuar?"
 
 #: src/bookmark.py:230
@@ -184,16 +184,16 @@ msgstr "Nome"
 
 #: src/bookmark.py:257
 msgid "Page"
-msgstr "P�gina"
+msgstr "Página"
 
 #: src/comment.py:16 src/preferences.py:301
 msgid "Comments"
-msgstr "Coment�rios"
+msgstr "Comentários"
 
 #: src/comment.py:53
 #, python-format
 msgid "Could not read {}"
-msgstr "N�o foi poss�vel ler {}"
+msgstr "Não foi possível ler {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -207,11 +207,11 @@ msgid ""
 "remove these files in order to save some disk space. Do you want these files "
 "to be removed for you now?"
 msgstr ""
-"Alguns arquivos antigos (que eram usados para salvar prefer�ncias, a "
-"biblioteca, favoritos e outros, em vers�es antigas do Comix) foram "
-"encontrados em seu computador. Se voc� n�o planeja usar as vers�es antigas "
-"do Comix novamente, voc� deve remover esses arquivos para economizar espa�o "
-"em disco. Deseja que esses arquivos sejam removidos para voc� agora?"
+"Alguns arquivos antigos (que eram usados para salvar preferências, a "
+"biblioteca, favoritos e outros, em versões antigas do Comix) foram "
+"encontrados em seu computador. Se você não planeja usar as versões antigas "
+"do Comix novamente, você deve remover esses arquivos para economizar espaço "
+"em disco. Deseja que esses arquivos sejam removidos para você agora?"
 
 #: src/edit.py:29
 msgid "Edit archive"
@@ -231,15 +231,15 @@ msgstr "Outros arquivos"
 
 #: src/edit.py:101
 msgid "The new archive could not be saved!"
-msgstr "O novo arquivo n�o p�de ser gravado!"
+msgstr "O novo arquivo não pôde ser gravado!"
 
 #: src/edit.py:103
 msgid "The original files have not been removed."
-msgstr "Os arquivos originais n�o foram removidos."
+msgstr "Os arquivos originais não foram removidos."
 
 #: src/edit.py:117
 msgid "Archives are stored as ZIP files."
-msgstr "Arquivos s�o gravados em formato ZIP."
+msgstr "Arquivos são gravados em formato ZIP."
 
 #: src/edit.py:170 src/edit.py:288
 msgid "Remove from archive"
@@ -250,8 +250,8 @@ msgid ""
 "Please note that the only files that are automatically added to this list "
 "are those files in archives that Comix recognizes as comments."
 msgstr ""
-"Por favor, note que os �nicos arquivos adicionados automaticamente nesta "
-"lista s�o os arquivos que o Comix reconhece como coment�rios."
+"Por favor, note que os únicos arquivos adicionados automaticamente nesta "
+"lista são os arquivos que o Comix reconhece como comentários."
 
 #: src/edit.py:273
 msgid "Size"
@@ -263,7 +263,7 @@ msgstr "Melhorar imagem"
 
 #: src/enhance.py:52
 msgid "Defaults"
-msgstr "Padr�es"
+msgstr "Padrões"
 
 #: src/enhance.py:79
 msgid "Brightness"
@@ -275,7 +275,7 @@ msgstr "Contraste"
 
 #: src/enhance.py:101
 msgid "Saturation"
-msgstr "Satura��o"
+msgstr "Saturação"
 
 #: src/enhance.py:112
 msgid "Sharpness"
@@ -324,11 +324,11 @@ msgstr "Arquivos tar"
 #: src/filechooser.py:139
 #, python-format
 msgid "A file named '{}' already exists. Do you want to replace it?"
-msgstr "Um arquivo com o nome '{}' j� existe. Deseja substitu�-lo?"
+msgstr "Um arquivo com o nome '{}' já existe. Deseja substituí-lo?"
 
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
-msgstr "A substitui��o sobreescrever� seu conte�do."
+msgstr "A substituição sobreescreverá seu conteúdo."
 
 #: src/filechooser.py:187 src/filechooser.py:304
 msgid "All images"
@@ -344,32 +344,32 @@ msgstr "Imagens PNG"
 
 #: src/filechooser.py:231
 msgid "Automatically add the books to this collection"
-msgstr "Adicionar livros a esta cole��o automaticamente"
+msgstr "Adicionar livros a esta coleção automaticamente"
 
 #: src/filehandler.py:209
 #, python-format
 msgid "Could not open {}: Is a directory."
-msgstr "Imposs�vel abrir {}: � um diret�rio."
+msgstr "Impossível abrir {}: É um diretório."
 
 #: src/filehandler.py:213
 #, python-format
 msgid "Could not open {}: No such file."
-msgstr "Imposs�vel abrir {}: Arquivo n�o existe."
+msgstr "Impossível abrir {}: Arquivo não existe."
 
 #: src/filehandler.py:217
 #, python-format
 msgid "Could not open {}: Permission denied."
-msgstr "Imposs�vel abrir {}: Permiss�o negada."
+msgstr "Impossível abrir {}: Permissão negada."
 
 #: src/filehandler.py:222
 #, python-format
 msgid "Could not open {}: Unknown file type."
-msgstr "Imposs�vel abrir {}: Tipo de arquivo desconhecido."
+msgstr "Impossível abrir {}: Tipo de arquivo desconhecido."
 
 #: src/filehandler.py:285
 #, python-format
 msgid "No images in '{}'"
-msgstr "N�o h� imagens em '{}'"
+msgstr "Não há imagens em '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -377,7 +377,7 @@ msgstr "Tipo de arquivo desconhecido"
 
 #: src/librarybackend.py:271 src/librarybackend.py:273
 msgid "(Copy)"
-msgstr "(C�pia)"
+msgstr "(Cópia)"
 
 #: src/library.py:38
 msgid "Library"
@@ -389,11 +389,11 @@ msgstr "Renomear..."
 
 #: src/library.py:152
 msgid "Duplicate collection"
-msgstr "Cole��o duplicada"
+msgstr "Coleção duplicada"
 
 #: src/library.py:154
 msgid "Remove collection..."
-msgstr "Remover cole��o..."
+msgstr "Remover coleção..."
 
 #: src/library.py:202
 msgid "All books"
@@ -401,36 +401,36 @@ msgstr "Todos os livros"
 
 #: src/library.py:231
 msgid "Remove collection from the library?"
-msgstr "Remover cole��o da biblioteca?"
+msgstr "Remover coleção da biblioteca?"
 
 #: src/library.py:233
 msgid ""
 "The selected collection will be removed from the library (but the books and "
 "subcollections in it will remain). Are you sure that you want to continue?"
 msgstr ""
-"A cole��o selecionada ser� removida da biblioteca (mas os livros e as sub-"
-"cole��o dentro dela permanecer�o). Tem certeza de que deseja continuar?"
+"A coleção selecionada será removida da biblioteca (mas os livros e as sub-"
+"coleção dentro dela permanecerão). Tem certeza de que deseja continuar?"
 
 #: src/library.py:251
 msgid "Rename collection?"
-msgstr "Renomear cole��o?"
+msgstr "Renomear coleção?"
 
 #: src/library.py:253
 msgid "Please enter a new name for the selected collection."
-msgstr "Por favor, digite um novo nome para a cole��o selecionada."
+msgstr "Por favor, digite um novo nome para a coleção selecionada."
 
 #: src/library.py:271
 #, python-format
 msgid "Could not change the name to '{}'."
-msgstr "Imposs�vel renomear para '{}'."
+msgstr "Impossível renomear para '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
-msgstr "Uma cole��o com esse nome j� existe."
+msgstr "Uma coleção com esse nome já existe."
 
 #: src/library.py:285
 msgid "Could not duplicate collection."
-msgstr "Imposs�vel duplicar cole��o."
+msgstr "Impossível duplicar coleção."
 
 #: src/library.py:382
 msgid "Root"
@@ -439,10 +439,9 @@ msgstr "Raiz"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '{subcollection}' in the collection '{supercollection}"
-"s'."
+"Put the collection '{subcollection}' in the collection '{supercollection}'."
 msgstr ""
-"Coloque a cole��o '{subcollection}' na cole��o '{supercollection}'."
+"Coloque a coleção '{subcollection}' na coleção '{supercollection}'."
 
 #: src/library.py:407
 #, python-format
@@ -458,7 +457,7 @@ msgstr ""
 
 #: src/library.py:493
 msgid "Remove from this collection"
-msgstr "Remover desta cole��o"
+msgstr "Remover desta coleção"
 
 #: src/library.py:496
 msgid "Remove from the library..."
@@ -478,8 +477,8 @@ msgid ""
 "The selected books will be removed from the library (but the original files "
 "will be untouched). Are you sure that you want to continue?"
 msgstr ""
-"Os livros selecionados ser�o removidos da biblioteca (mas os arquivos "
-"originais n�o ser�o modificados). Tem certeza de que deseja continuar?"
+"Os livros selecionados serão removidos da biblioteca (mas os arquivos "
+"originais não serão modificados). Tem certeza de que deseja continuar?"
 
 #: src/library.py:610
 #, python-format
@@ -495,8 +494,8 @@ msgid ""
 "Display only those books that have the specified text string in their full "
 "path. The search is not case sensitive."
 msgstr ""
-"Mostrar s� os livros que t�m o texto especificado no seu caminho completo. A "
-"busca n�o � sens�vel a mai�scula e min�scula."
+"Mostrar só os livros que têm o texto especificado no seu caminho completo. A "
+"busca não é sensível a maiúscula e minúscula."
 
 #: src/library.py:777
 msgid "Cover size"
@@ -508,15 +507,15 @@ msgstr "Adicionar livros"
 
 #: src/library.py:794
 msgid "Add more books to the library."
-msgstr "Adicionar mais livros � biblioteca."
+msgstr "Adicionar mais livros à biblioteca."
 
 #: src/library.py:796
 msgid "Add collection"
-msgstr "Adicionar cole��o"
+msgstr "Adicionar coleção"
 
 #: src/library.py:801
 msgid "Add a new empty collection."
-msgstr "Adicionar nova cole��o vazia."
+msgstr "Adicionar nova coleção vazia."
 
 #: src/library.py:807
 msgid "Open the selected book."
@@ -525,24 +524,24 @@ msgstr "Abrir o livro selecionado."
 #: src/library.py:833 src/properties.py:118
 #, python-format
 msgid "{} pages"
-msgstr "{} p�ginas"
+msgstr "{} páginas"
 
 #: src/library.py:855
 msgid "Add new collection?"
-msgstr "Adicionar nova cole��o?"
+msgstr "Adicionar nova coleção?"
 
 #: src/library.py:857
 msgid "Please enter a name for the new collection."
-msgstr "Por favor, digite o nome da nova cole��o."
+msgstr "Por favor, digite o nome da nova coleção."
 
 #: src/library.py:863
 msgid "New collection"
-msgstr "Nova cole��o"
+msgstr "Nova coleção"
 
 #: src/library.py:877
 #, python-format
 msgid "Could not add a new collection called '{}'."
-msgstr "Imposs�vel adicionar uma nova cole��o chamada '{}'."
+msgstr "Impossível adicionar uma nova coleção chamada '{}'."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -559,11 +558,11 @@ msgstr "Adicionando '{}'..."
 
 #: src/main.py:704
 msgid "SLIDESHOW"
-msgstr "Apresenta��o de slides"
+msgstr "Apresentação de slides"
 
 #: src/preferences.py:82
 msgid "Preferences"
-msgstr "Prefer�ncias"
+msgstr "Preferências"
 
 #: src/preferences.py:97
 msgid "Background"
@@ -579,12 +578,12 @@ msgstr "Sempre usar essa cor como cor de fundo."
 
 #: src/preferences.py:106
 msgid "Use dynamic background colour."
-msgstr "Usar cor de fundo din�mica."
+msgstr "Usar cor de fundo dinâmica."
 
 #: src/preferences.py:110
 msgid "Automatically pick a background colour that fits the viewed image."
 msgstr ""
-"Escolher uma cor de fundo compat�vel com a imagem visualizada "
+"Escolher uma cor de fundo compatível com a imagem visualizada "
 "automaticamente."
 
 #: src/preferences.py:113
@@ -597,7 +596,7 @@ msgstr "Tamanho da miniatura (em pixels)"
 
 #: src/preferences.py:121
 msgid "Show page numbers on thumbnails."
-msgstr "Mostrar n�meros de p�gina nas miniaturas."
+msgstr "Mostrar números de página nas miniaturas."
 
 #: src/preferences.py:128
 msgid "Magnifying Glass"
@@ -612,7 +611,7 @@ msgid ""
 "Set the size of the magnifying glass. It is a square with a side of this "
 "many pixels."
 msgstr ""
-"Ajustar o tamanho da lente de aumento. � um quadrado com esse tamanho de "
+"Ajustar o tamanho da lente de aumento. É um quadrado com esse tamanho de "
 "pixels."
 
 #: src/preferences.py:137
@@ -637,13 +636,13 @@ msgid ""
 "current zoom mode requests it. If this preference is unset, images are never "
 "scaled to be larger than their original size."
 msgstr ""
-"Esticar imagens para um tamanho que � maior que seu tamanho original se o "
-"modo de zoom atual pedir. Se esta prefer�ncia n�o estiver marcada, as "
-"imagens nunca ser�o vistas maior que seu tamanho original."
+"Esticar imagens para um tamanho que é maior que seu tamanho original se o "
+"modo de zoom atual pedir. Se esta preferência não estiver marcada, as "
+"imagens nunca serão vistas maior que seu tamanho original."
 
 #: src/preferences.py:155
 msgid "Transparency"
-msgstr "Transpar�ncia"
+msgstr "Transparência"
 
 #: src/preferences.py:157
 msgid "Use checkered background for transparent images."
@@ -655,11 +654,11 @@ msgid ""
 "is unset, the background is plain white instead."
 msgstr ""
 "Usar fundo quadriculado cinza para imagens transparentes. Se esta "
-"prefer�ncia n�o estiver marcada, o fundo usado � branco."
+"preferência não estiver marcada, o fundo usado é branco."
 
 #: src/preferences.py:165
 msgid "Appearance"
-msgstr "Apar�ncia"
+msgstr "Aparência"
 
 #: src/preferences.py:171
 msgid "Scroll"
@@ -667,7 +666,7 @@ msgstr "Rolagem"
 
 #: src/preferences.py:173
 msgid "Use smart space key scrolling."
-msgstr "Usar rolagem inteligente com tecla de espa�o."
+msgstr "Usar rolagem inteligente com tecla de espaço."
 
 #: src/preferences.py:178
 msgid ""
@@ -676,14 +675,14 @@ msgid ""
 "also scrolls sideways and so tries to follow the natural reading order of "
 "the comic book."
 msgstr ""
-"Usar rolagem inteligente com telca de espa�o. Normalmente, a tecla de espa�o "
-"s� rola para baixo (ou para cima quando shift � apertado). No entanto, com "
-"esta perfer�ncia tamb�m rola para os lados e tenta seguir a ordem natural de "
-"leitura de uma hist�ria em quadrinhos."
+"Usar rolagem inteligente com telca de espaço. Normalmente, a tecla de espaço "
+"só rola para baixo (ou para cima quando shift é apertado). No entanto, com "
+"esta perferência também rola para os lados e tenta seguir a ordem natural de "
+"leitura de uma história em quadrinhos."
 
 #: src/preferences.py:182
 msgid "Flip pages when scrolling off the edges of the page."
-msgstr "Virar p�ginas quando rolar para fora da borda da p�gina."
+msgstr "Virar páginas quando rolar para fora da borda da página."
 
 #: src/preferences.py:187
 msgid ""
@@ -691,28 +690,28 @@ msgid ""
 "arrow keys. It takes three consecutive \"steps\" with the scroll wheel or "
 "the arrow keys for the pages to be flipped."
 msgstr ""
-"Virar p�ginas quando rolar \"para fora da p�gina\" com a roda de roladagem "
-"ou teclas de seta. S�o necess�rios tr�s \"passos\" consecutivos com a roda "
-"de rolagem ou teclas de seta para que as p�ginas sejam viradas."
+"Virar páginas quando rolar \"para fora da página\" com a roda de roladagem "
+"ou teclas de seta. São necessários três \"passos\" consecutivos com a roda "
+"de rolagem ou teclas de seta para que as páginas sejam viradas."
 
 #: src/preferences.py:190 src/ui.py:298
 msgid "Double page mode"
-msgstr "Modo de p�gina dupla"
+msgstr "Modo de página dupla"
 
 #: src/preferences.py:192
 msgid "Flip two pages in double page mode."
-msgstr "Virar duas p�ginas em modo de p�gina dupla."
+msgstr "Virar duas páginas em modo de página dupla."
 
 #: src/preferences.py:197
 msgid ""
 "Flip two pages, instead of one, each time we flip pages in double page mode."
 msgstr ""
-"Virar duas p�ginas, ao inv�s de uma, cada vez que virar p�gina em modo de "
-"p�gina dupla."
+"Virar duas páginas, ao invés de uma, cada vez que virar página em modo de "
+"página dupla."
 
 #: src/preferences.py:200
 msgid "Show only one wide image in double page mode."
-msgstr "Mostrar s� uma imagem larga em modo de p�gina dupl.a"
+msgstr "Mostrar só uma imagem larga em modo de página dupl.a"
 
 #: src/preferences.py:206
 msgid ""
@@ -720,9 +719,9 @@ msgid ""
 "height. The result of this is that scans that span two pages are displayed "
 "properly (i.e. alone) also in double page mode."
 msgstr ""
-"Mostra s� uma imagem em modo de p�gina dupla, se a largura da imagem exceder "
-"sua altura. O resultado disto � que scans que passem de duas p�ginas s�o "
-"mostrados adequadamente (isto �, sozinhos) tamb�m em modo de p�gina dupla."
+"Mostra só uma imagem em modo de página dupla, se a largura da imagem exceder "
+"sua altura. O resultado disto é que scans que passem de duas páginas são "
+"mostrados adequadamente (isto é, sozinhos) também em modo de página dupla."
 
 #: src/preferences.py:209
 msgid "Files"
@@ -730,19 +729,19 @@ msgstr "Arquivos"
 
 #: src/preferences.py:211
 msgid "Automatically open the next archive."
-msgstr "Abrir o pr�ximo arquivo automaticamente."
+msgstr "Abrir o próximo arquivo automaticamente."
 
 #: src/preferences.py:216
 msgid ""
 "Automatically open the next archive in the directory when flipping past the "
 "last page, or the previous archive when flipping past the first page."
 msgstr ""
-"Abre o pr�ximo arquivo do diret�rio automaticamente quando virar ap�s a "
-"�ltima p�gina, ou o arquivo anterior quando virar antes da primeira p�gina."
+"Abre o próximo arquivo do diretório automaticamente quando virar após a "
+"última página, ou o arquivo anterior quando virar antes da primeira página."
 
 #: src/preferences.py:219
 msgid "Automatically open the last viewed file on startup."
-msgstr "Abrir o �ltimo arquivo visto automaticamente quando abrir."
+msgstr "Abrir o último arquivo visto automaticamente quando abrir."
 
 #: src/preferences.py:224
 msgid ""
@@ -750,18 +749,18 @@ msgid ""
 "closed."
 msgstr ""
 "Abre, quando inicia, o arquivo que estava aberto quando o Comix foi fechado "
-"da �ltima vez."
+"da última vez."
 
 #: src/preferences.py:227
 msgid "Store information about recently opened files."
-msgstr "Guarda informa��es sobre arquivos abertos recentemente."
+msgstr "Guarda informações sobre arquivos abertos recentemente."
 
 #: src/preferences.py:232
 msgid ""
 "Add information about all files opened from within Comix to the shared "
 "recent files list."
 msgstr ""
-"Adicionar informa��es sobre todos os arquivos abertos dentro do Comix para a "
+"Adicionar informações sobre todos os arquivos abertos dentro do Comix para a "
 "lista de arquivos compartilhados recentes."
 
 #: src/preferences.py:235
@@ -774,8 +773,8 @@ msgid ""
 "specification. These thumbnails are shared by many other applications, such "
 "as most file managers."
 msgstr ""
-"Guarda miniaturas de arquivos abertos de acordo com a especifica��o do "
-"freedesktop.org. Essas miniaturas s�o compartilhadas por v�rios outros "
+"Guarda miniaturas de arquivos abertos de acordo com a especificação do "
+"freedesktop.org. Essas miniaturas são compartilhadas por vários outros "
 "aplicativos, como a maior parte dos gerenciadores de arquivos."
 
 #: src/preferences.py:243
@@ -784,7 +783,7 @@ msgstr "Cache"
 
 #: src/preferences.py:244
 msgid "Use a cache to speed up browsing."
-msgstr "Usar um cache para aumentar velocidade de navega��o."
+msgstr "Usar um cache para aumentar velocidade de navegação."
 
 #: src/preferences.py:248
 msgid ""
@@ -793,10 +792,10 @@ msgid ""
 "recommended that you have this preference set, unless you are running short "
 "on free RAM."
 msgstr ""
-"Faz cache das imagens que est�o pr�ximas a imagem vista atualmente para "
-"acelerar a navega��o. J� que a melhoria de velocidade � grande, � "
-"recomend�vel ter esta prefer�ncia marcada, a menos que voc� esteja com pouca "
-"mem�ria RAM."
+"Faz cache das imagens que estão próximas a imagem vista atualmente para "
+"acelerar a navegação. Já que a melhoria de velocidade é grande, é "
+"recomendável ter esta preferência marcada, a menos que você esteja com pouca "
+"memória RAM."
 
 #: src/preferences.py:250
 msgid "Behaviour"
@@ -804,23 +803,23 @@ msgstr "Comportamento"
 
 #: src/preferences.py:256
 msgid "Default modes"
-msgstr "Modos padr�o"
+msgstr "Modos padrão"
 
 #: src/preferences.py:258
 msgid "Use double page mode by default."
-msgstr "Usar p�gina dupla por padr�o."
+msgstr "Usar página dupla por padrão."
 
 #: src/preferences.py:263
 msgid "Use fullscreen by default."
-msgstr "Usar tela cheia por padr�o."
+msgstr "Usar tela cheia por padrão."
 
 #: src/preferences.py:268
 msgid "Use manga mode by default."
-msgstr "Usar modo mang� por padr�o."
+msgstr "Usar modo mangá por padrão."
 
 #: src/preferences.py:273
 msgid "Default zoom mode"
-msgstr "Modo de zoom padr�o"
+msgstr "Modo de zoom padrão"
 
 #: src/preferences.py:275 src/ui.py:290
 msgid "Best fit mode"
@@ -844,19 +843,19 @@ msgstr "Tela cheia"
 
 #: src/preferences.py:286
 msgid "Automatically hide all toolbars in fullscreen."
-msgstr "Esconder todas as barras de ferramenta por padr�o em tela cheia."
+msgstr "Esconder todas as barras de ferramenta por padrão em tela cheia."
 
 #: src/preferences.py:292
 msgid "Slideshow"
-msgstr "Apresenta��o de slides"
+msgstr "Apresentação de slides"
 
 #: src/preferences.py:293
 msgid "Slideshow delay (in seconds)"
-msgstr "Espera da apresenta��o de slides (em segundos)"
+msgstr "Espera da apresentação de slides (em segundos)"
 
 #: src/preferences.py:302
 msgid "Comment extensions"
-msgstr "Comentar extens�es"
+msgstr "Comentar extensões"
 
 #: src/preferences.py:308
 msgid ""
@@ -864,7 +863,7 @@ msgid ""
 "as comments."
 msgstr ""
 "Tratar todos os arquivos avulsos dentro de arquivos, incluindo os que tem "
-"termina��o de arquivo, como coment�rios."
+"terminação de arquivo, como comentários."
 
 #: src/preferences.py:311
 msgid "Rotation"
@@ -891,7 +890,7 @@ msgstr "Propriedades"
 #: src/properties.py:119
 #, python-format
 msgid "{} comments"
-msgstr "{} coment�rios"
+msgstr "{} comentários"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -907,7 +906,7 @@ msgstr "Modificado"
 
 #: src/properties.py:135 src/properties.py:169
 msgid "Permissions"
-msgstr "Permiss�es"
+msgstr "Permissões"
 
 #: src/properties.py:136 src/properties.py:170
 msgid "Owner"
@@ -923,7 +922,7 @@ msgstr "Imagem"
 
 #: src/thumbremover.py:24
 msgid "Thumbnail maintenance"
-msgstr "Manuten��o de miniatura"
+msgstr "Manutenção de miniatura"
 
 #: src/thumbremover.py:26
 msgid "Cleanup"
@@ -941,20 +940,20 @@ msgid ""
 "files have been removed - wasting space. This dialog can cleanup your stored "
 "thumbnails by removing orphaned and outdated thumbnails."
 msgstr ""
-"Miniaturas para arquivos avulsos (como arquivos de imagem e hist�rias em "
-"quadrinhos) s�o guardadas em seu diret�rio de usu�rio. Muitos aplicativos "
+"Miniaturas para arquivos avulsos (como arquivos de imagem e histórias em "
+"quadrinhos) são guardadas em seu diretório de usuário. Muitos aplicativos "
 "diferentes usam e criam essas miniaturas, mas algumas vezes as miniaturas "
 "permanecem apesar de os arquivos originais terem sido removidos - "
-"despedi�ando espa�o. Este di�logo pode limpar miniaturas ao remover "
-"minaturas �rf�s e ultrapassadas."
+"despediçando espaço. Este diálogo pode limpar miniaturas ao remover "
+"minaturas órfãs e ultrapassadas."
 
 #: src/thumbremover.py:60
 msgid "Thumbnail directory"
-msgstr "Diret�rio de miniaturas"
+msgstr "Diretório de miniaturas"
 
 #: src/thumbremover.py:67
 msgid "Total number of thumbnails"
-msgstr "N�mero total de miniaturas"
+msgstr "Número total de miniaturas"
 
 #: src/thumbremover.py:70 src/thumbremover.py:77
 msgid "Calculating..."
@@ -966,7 +965,7 @@ msgstr "Tamanho total das miniaturas"
 
 #: src/thumbremover.py:82
 msgid "Do you want to cleanup orphaned and outdated thumbnails now?"
-msgstr "Deseja limpar miniaturas �rf�s ou ultrapassadas agora?"
+msgstr "Deseja limpar miniaturas órfãs ou ultrapassadas agora?"
 
 #: src/thumbremover.py:118
 msgid "Removing thumbnails"
@@ -974,7 +973,7 @@ msgstr "Removendo miniaturas"
 
 #: src/thumbremover.py:137
 msgid "Number of removed thumbnails"
-msgstr "N�mero de miniaturas removidas"
+msgstr "Número de miniaturas removidas"
 
 #: src/thumbremover.py:144
 msgid "Total size of removed thumbnails"
@@ -987,19 +986,19 @@ msgstr "Removida a miniatura de '{}'"
 
 #: src/ui.py:34
 msgid "_Next page"
-msgstr "_Pr�xima p�gina"
+msgstr "_Próxima página"
 
 #: src/ui.py:36
 msgid "_Previous page"
-msgstr "P�_gina anterior"
+msgstr "Pá_gina anterior"
 
 #: src/ui.py:38
 msgid "_First page"
-msgstr "P_rimeira p�gina"
+msgstr "P_rimeira página"
 
 #: src/ui.py:40
 msgid "_Last page"
-msgstr "_�ltima p�gina"
+msgstr "_Última página"
 
 #: src/ui.py:42
 msgid "_Zoom in"
@@ -1023,15 +1022,15 @@ msgstr "_Sair"
 
 #: src/ui.py:52
 msgid "_Rotate 90 degrees CW"
-msgstr "Ro_ta��o de 90 graus hor�rios"
+msgstr "Ro_tação de 90 graus horários"
 
 #: src/ui.py:54
 msgid "Rotate 180 de_grees"
-msgstr "Rota��o de 180 graus"
+msgstr "Rotação de 180 graus"
 
 #: src/ui.py:56
 msgid "Rotat_e 90 degrees CCW"
-msgstr "Ro_ta��o de 90 graus anti-hor�rios"
+msgstr "Ro_tação de 90 graus anti-horários"
 
 #: src/ui.py:58
 msgid "Fli_p horizontally"
@@ -1087,7 +1086,7 @@ msgstr "Tela cheia"
 
 #: src/ui.py:77
 msgid "_Double page mode"
-msgstr "Modo de p�gina dupla"
+msgstr "Modo de página dupla"
 
 #: src/ui.py:79
 msgid "_Toolbar"
@@ -1115,15 +1114,15 @@ msgstr "Esconder todos"
 
 #: src/ui.py:91
 msgid "_Manga mode"
-msgstr "Modo mang�"
+msgstr "Modo mangá"
 
 #: src/ui.py:93
 msgid "_Keep transformation"
-msgstr "Manter transforma��o"
+msgstr "Manter transformação"
 
 #: src/ui.py:95
 msgid "Run _slideshow"
-msgstr "Rodar apresenta��o de slides"
+msgstr "Rodar apresentação de slides"
 
 #: src/ui.py:97
 msgid "Magnifying _glass"
@@ -1151,7 +1150,7 @@ msgstr "Sobre"
 
 #: src/ui.py:117
 msgid "_View comments..."
-msgstr "Ver coment�rios..."
+msgstr "Ver comentários..."
 
 #: src/ui.py:119
 msgid "_Edit archive..."
@@ -1171,11 +1170,11 @@ msgstr "Melhorar imagem..."
 
 #: src/ui.py:128
 msgid "_Thumbnail maintenance..."
-msgstr "Manuten��o de miniaturas..."
+msgstr "Manutenção de miniaturas..."
 
 #: src/ui.py:130
 msgid "Pr_eferences"
-msgstr "Prefer�ncias"
+msgstr "Preferências"
 
 #: src/ui.py:134
 msgid "_Library..."
@@ -1183,23 +1182,23 @@ msgstr "Biblioteca..."
 
 #: src/ui.py:284
 msgid "First page"
-msgstr "Primeira p�gina"
+msgstr "Primeira página"
 
 #: src/ui.py:286
 msgid "Previous page"
-msgstr "P�gina anterior"
+msgstr "Página anterior"
 
 #: src/ui.py:287
 msgid "Next page"
-msgstr "Pr�xima p�gina"
+msgstr "Próxima página"
 
 #: src/ui.py:288
 msgid "Last page"
-msgstr "�ltima p�gina"
+msgstr "Última página"
 
 #: src/ui.py:299
 msgid "Manga mode"
-msgstr "Modo mang�"
+msgstr "Modo mangá"
 
 #: src/ui.py:300
 msgid "Magnifying glass"

--- a/messages/ru/LC_MESSAGES/comix.po
+++ b/messages/ru/LC_MESSAGES/comix.po
@@ -294,8 +294,8 @@ msgstr "Комментарии"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Не могу прочитать %s"
+msgid "Could not read {}"
+msgstr "Не могу прочитать {}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -482,8 +482,8 @@ msgstr "Tar архивы"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Файл с именем '%s' уже существует. Вы хотите заменить его?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Файл с именем '{}' уже существует. Вы хотите заменить его?"
 
 #
 # File: src/filechooser.py, line: 128
@@ -522,36 +522,36 @@ msgstr "Автоматически добавить книги в эту кол�
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Не могу открыть %s: Это каталог."
+msgid "Could not open {}: Is a directory."
+msgstr "Не могу открыть {}: Это каталог."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Не могу открыть %s: Нет такого файла."
+msgid "Could not open {}: No such file."
+msgstr "Не могу открыть {}: Нет такого файла."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Не могу открыть %s: Не хватает прав."
+msgid "Could not open {}: Permission denied."
+msgstr "Не могу открыть {}: Не хватает прав."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Не могу открыть %s: Неизвестный тип файла."
+msgid "Could not open {}: Unknown file type."
+msgstr "Не могу открыть {}: Неизвестный тип файла."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Нет изображений в '%s'"
+msgid "No images in '{}'"
+msgstr "Нет изображений в '{}'"
 
 #
 # File: src/filehandler.py, line: 411
@@ -628,8 +628,8 @@ msgstr "Пожалуйста, введите новое имя для выбра
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Невозможно изменить имя на '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Невозможно изменить имя на '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -655,26 +655,26 @@ msgstr "Корень"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Поместить коллекцию '%(subcollection)s' в коллекцию '%(supercollection)s'."
+"Поместить коллекцию '{subcollection}' в коллекцию '{supercollection}'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Добавить книги в '%s'."
+msgid "Add books to '{}'."
+msgstr "Добавить книги в '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Переместить книги из '%(source collection)s' в '%(destination collection)s'."
+"Переместить книги из '{source collection}' в '{destination collection}'."
 
 #
 # File: src/library.py, line: 492
@@ -692,8 +692,8 @@ msgstr "Удалить из библиотеки..."
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Удалено %(num)d книг(а, и) из '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Удалено {num} книг(а, и) из '{collection}'."
 
 #
 # File: src/library.py, line: 597
@@ -715,8 +715,8 @@ msgstr ""
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Удалено %d книг(а, и) из коллекции."
+msgid "Removed {} book(s) from the library."
+msgstr "Удалено {} книг(а, и) из коллекции."
 
 #
 # File: src/library.py, line: 769
@@ -775,8 +775,8 @@ msgstr "Открыть выбранную книгу."
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d страниц"
+msgid "{} pages"
+msgstr "{} страниц"
 
 #
 # File: src/library.py, line: 854
@@ -800,8 +800,8 @@ msgstr "Новая коллекция"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Не могу добавить новую коллекцию '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Не могу добавить новую коллекцию '{}'."
 
 #
 # File: src/library.py, line: 910
@@ -819,8 +819,8 @@ msgstr "Добавлены книги"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Добавление '%s'..."
+msgid "Adding '{}'..."
+msgstr "Добавление '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -1277,8 +1277,8 @@ msgstr "Свойства"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d комментариев"
+msgid "{} comments"
+msgstr "{} комментариев"
 
 #
 # File: src/properties.py, line: 124
@@ -1414,8 +1414,8 @@ msgstr "Общий размер удаленных миниатюр"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Удалена миниатюра для '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Удалена миниатюра для '{}'"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/sv/LC_MESSAGES/comix.po
+++ b/messages/sv/LC_MESSAGES/comix.po
@@ -1,5 +1,5 @@
 # Svensk katalog.
-# Översatt 2005-2006 av
+# ï¿½versatt 2005-2006 av
 # Pontus Ekberg <herrekberg@users.sourceforge.net>.
 #
 msgid ""
@@ -27,19 +27,19 @@ msgstr "Om"
 # File: src/about.py, line: 55
 #: src/about.py:56
 msgid "Comix is an image viewer specifically designed to handle comic books."
-msgstr "Comix är en bildvisare som är särskilt designad för att visa serier."
+msgstr "Comix ï¿½r en bildvisare som ï¿½r sï¿½rskilt designad fï¿½r att visa serier."
 
 #
 # File: src/about.py, line: 57
 #: src/about.py:58
 msgid "It reads ZIP, RAR and tar archives, as well as plain image files."
-msgstr "Den läser ZIP-, RAR- och tar-arkiv, samt vanliga bildfiler."
+msgstr "Den lï¿½ser ZIP-, RAR- och tar-arkiv, samt vanliga bildfiler."
 
 #
 # File: src/about.py, line: 59
 #: src/about.py:60
 msgid "Comix is licensed under the GNU General Public License."
-msgstr "Comix är licensierat under GNU General Public License."
+msgstr "Comix ï¿½r licensierat under GNU General Public License."
 
 #
 # File: src/about.py, line: 75
@@ -52,123 +52,123 @@ msgstr "Utvecklare"
 #: src/about.py:84
 #: src/about.py:85
 msgid "Simplified Chinese translation"
-msgstr "Förenklad kinesisk översättning"
+msgstr "Fï¿½renklad kinesisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 78
 #: src/about.py:86
 msgid "Spanish translation"
-msgstr "Spansk översättning"
+msgstr "Spansk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 79
 #: src/about.py:87
 msgid "Brazilian Portuguese translation"
-msgstr "Brasiliansk-portugisisk översättning"
+msgstr "Brasiliansk-portugisisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 81
 #: src/about.py:88
 msgid "German translation and Nautilus thumbnailer"
-msgstr "Tysk översättning och miniatyrbildsskapare för Nautilus"
+msgstr "Tysk ï¿½versï¿½ttning och miniatyrbildsskapare fï¿½r Nautilus"
 
 #
 # File: src/about.py, line: 82
 #: src/about.py:89
 #: src/about.py:90
 msgid "Italian translation"
-msgstr "Italiensk översättning"
+msgstr "Italiensk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 83
 #: src/about.py:91
 msgid "Dutch translation"
-msgstr "Nederländsk översättning"
+msgstr "Nederlï¿½ndsk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 84
 #: src/about.py:92
 #: src/about.py:93
 msgid "French translation"
-msgstr "Fransk översättning"
+msgstr "Fransk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 85
 #: src/about.py:94
 #: src/about.py:95
 msgid "Polish translation"
-msgstr "Polsk översättning"
+msgstr "Polsk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 86
 #: src/about.py:96
 msgid "Greek translation"
-msgstr "Grekisk översättning"
+msgstr "Grekisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 87
 #: src/about.py:97
 msgid "Catalan translation"
-msgstr "Katalansk översättning"
+msgstr "Katalansk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 88
 #: src/about.py:98
 #: src/about.py:99
 msgid "Traditional Chinese translation"
-msgstr "Traditionell kinesisk översättning"
+msgstr "Traditionell kinesisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 89
 #: src/about.py:100
 msgid "Japanese translation"
-msgstr "Japansk översättning"
+msgstr "Japansk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 90
 #: src/about.py:101
 msgid "Hungarian translation"
-msgstr "Ungersk översättning"
+msgstr "Ungersk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 91
 #: src/about.py:102
 msgid "Russian translation"
-msgstr "Rysk översättning"
+msgstr "Rysk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 92
 #: src/about.py:103
 msgid "Croatian translation"
-msgstr "Kroatisk översättning"
+msgstr "Kroatisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 93
 #: src/about.py:104
 msgid "Korean translation"
-msgstr "Koreansk översättning"
+msgstr "Koreansk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 94
 #: src/about.py:105
 msgid "Persian translation"
-msgstr "Persisk översättning"
+msgstr "Persisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 95
 #: src/about.py:106
 msgid "Indonesian translation"
-msgstr "Indonesisk översättning"
+msgstr "Indonesisk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 96
 #: src/about.py:107
 msgid "Czech translation"
-msgstr "Tjeckisk översättning"
+msgstr "Tjeckisk ï¿½versï¿½ttning"
 
 #: src/about.py:108
 msgid "Ukrainian translation"
-msgstr "Ukrainsk översättning"
+msgstr "Ukrainsk ï¿½versï¿½ttning"
 
 #
 # File: src/about.py, line: 97
@@ -192,7 +192,7 @@ msgstr "Kunde inte hitta RAR-filsuppackare!"
 # File: src/archive.py, line: 68
 #: src/archive.py:68
 msgid "You need either the <i>rar</i> or the <i>unrar</i> program installed in order to read RAR (.cbr) files."
-msgstr "Du behöver antingen programmet <i>rar</i> eller <i>unrar</i> installerat för att kunna läsa RAR-filer (.cbr)."
+msgstr "Du behï¿½ver antingen programmet <i>rar</i> eller <i>unrar</i> installerat fï¿½r att kunna lï¿½sa RAR-filer (.cbr)."
 
 #
 # File: src/archive.py, line: 301
@@ -228,37 +228,37 @@ msgstr "RAR-arkiv"
 # File: src/bookmark.py, line: 27
 #: src/bookmark.py:28
 msgid "_Add bookmark"
-msgstr "_Lägg till bokmärke"
+msgstr "_Lï¿½gg till bokmï¿½rke"
 
 #
 # File: src/bookmark.py, line: 29
 #: src/bookmark.py:30
 msgid "_Edit bookmarks..."
-msgstr "R_edigera bokmärken..."
+msgstr "R_edigera bokmï¿½rken..."
 
 #
 # File: src/bookmark.py, line: 31
 #: src/bookmark.py:32
 msgid "_Clear bookmarks..."
-msgstr "_Töm bokmärken..."
+msgstr "_Tï¿½m bokmï¿½rken..."
 
 #
 # File: src/bookmark.py, line: 77
 #: src/bookmark.py:78
 msgid "Clear all bookmarks?"
-msgstr "Töm alla bokmärken?"
+msgstr "Tï¿½m alla bokmï¿½rken?"
 
 #
 # File: src/bookmark.py, line: 79
 #: src/bookmark.py:80
 msgid "All stored bookmarks will be removed. Are you sure that you want to continue?"
-msgstr "Alla lagrade bokmärken kommer att tas bort. Är du säker på att du vill fortsätta?"
+msgstr "Alla lagrade bokmï¿½rken kommer att tas bort. ï¿½r du sï¿½ker pï¿½ att du vill fortsï¿½tta?"
 
 #
 # File: src/bookmark.py, line: 229
 #: src/bookmark.py:230
 msgid "Edit bookmarks"
-msgstr "Redigera bokmärken"
+msgstr "Redigera bokmï¿½rken"
 
 #
 # File: src/bookmark.py, line: 255
@@ -286,20 +286,20 @@ msgstr "Kommentarer"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Kunde inte läsa %s"
+msgid "Could not read {}"
+msgstr "Kunde inte lï¿½sa {}"
 
 #
 # File: src/deprecated.py, line: 16
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
-msgstr "Det finns utdaterade filer kvarlämnade på din dator."
+msgstr "Det finns utdaterade filer kvarlï¿½mnade pï¿½ din dator."
 
 #
 # File: src/deprecated.py, line: 22
 #: src/deprecated.py:22
 msgid "Some old files (that were used for storing preferences, the library, bookmarks etc. for older versions of Comix) were found on your computer. If you do not plan on using the older versions of Comix again, you should remove these files in order to save some disk space. Do you want these files to be removed for you now?"
-msgstr "Några gamla filer (som användes för att lagra inställningar, biblioteket, bokmärken etc. för äldre versioner av Comix) har hittats på din dator. Om du inte planerar att använda de äldre versionerna av Comix igen, så bör du ta bort dessa filer för att spara diskutrymme. Vill du att dessa filer tas bort åt dig nu?"
+msgstr "Nï¿½gra gamla filer (som anvï¿½ndes fï¿½r att lagra instï¿½llningar, biblioteket, bokmï¿½rken etc. fï¿½r ï¿½ldre versioner av Comix) har hittats pï¿½ din dator. Om du inte planerar att anvï¿½nda de ï¿½ldre versionerna av Comix igen, sï¿½ bï¿½r du ta bort dessa filer fï¿½r att spara diskutrymme. Vill du att dessa filer tas bort ï¿½t dig nu?"
 
 #
 # File: src/edit.py, line: 28
@@ -349,13 +349,13 @@ msgstr "Arkiven sparas i ZIP-format."
 #: src/edit.py:170
 #: src/edit.py:288
 msgid "Remove from archive"
-msgstr "Ta bort från arkiv"
+msgstr "Ta bort frï¿½n arkiv"
 
 #
 # File: src/edit.py, line: 255
 #: src/edit.py:258
 msgid "Please note that the only files that are automatically added to this list are those files in archives that Comix recognizes as comments."
-msgstr "Notera att de enda filer som automatiskt läggs till i denna lista är de filer i arkiv som Comix känner igen som kommentarer."
+msgstr "Notera att de enda filer som automatiskt lï¿½ggs till i denna lista ï¿½r de filer i arkiv som Comix kï¿½nner igen som kommentarer."
 
 #
 # File: src/edit.py, line: 270
@@ -367,13 +367,13 @@ msgstr "Storlek"
 # File: src/enhance.py, line: 51
 #: src/enhance.py:51
 msgid "Enhance image"
-msgstr "Förbättra bild"
+msgstr "Fï¿½rbï¿½ttra bild"
 
 #
 # File: src/enhance.py, line: 52
 #: src/enhance.py:52
 msgid "Defaults"
-msgstr "Återställ"
+msgstr "ï¿½terstï¿½ll"
 
 #
 # File: src/enhance.py, line: 79
@@ -391,13 +391,13 @@ msgstr "Kontrast"
 # File: src/enhance.py, line: 101
 #: src/enhance.py:101
 msgid "Saturation"
-msgstr "Färgmättnad"
+msgstr "Fï¿½rgmï¿½ttnad"
 
 #
 # File: src/enhance.py, line: 112
 #: src/enhance.py:112
 msgid "Sharpness"
-msgstr "Skärpa"
+msgstr "Skï¿½rpa"
 
 #
 # File: src/enhance.py, line: 126
@@ -409,7 +409,7 @@ msgstr "Justera kontrast automatiskt."
 # File: src/enhance.py, line: 128
 #: src/enhance.py:128
 msgid "Automatically adjust contrast (both lightness and darkness), separately for each colour band."
-msgstr "Justera kontrast automatiskt (både ljushet och mörkhet), separat för varje färgkomponent."
+msgstr "Justera kontrast automatiskt (bï¿½de ljushet och mï¿½rkhet), separat fï¿½r varje fï¿½rgkomponent."
 
 #
 # File: src/filechooser.py, line: 35
@@ -417,7 +417,7 @@ msgstr "Justera kontrast automatiskt (både ljushet och mörkhet), separat för var
 #: src/filechooser.py:38
 #: src/library.py:490
 msgid "Open"
-msgstr "Öppna"
+msgstr "ï¿½ppna"
 
 #
 # File: src/filechooser.py, line: 39
@@ -459,14 +459,14 @@ msgstr "Tar-arkiv"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "En fil med namnet '%s' finns redan. Vill du ersätta den?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "En fil med namnet '{}' finns redan. Vill du ersï¿½tta den?"
 
 #
 # File: src/filechooser.py, line: 128
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
-msgstr "Ersätts filen så kommer dess innehåll att skrivas över."
+msgstr "Ersï¿½tts filen sï¿½ kommer dess innehï¿½ll att skrivas ï¿½ver."
 
 #
 # File: src/filechooser.py, line: 171
@@ -496,48 +496,48 @@ msgstr "PNG-bilder"
 # File: src/filechooser.py, line: 195
 #: src/filechooser.py:231
 msgid "Automatically add the books to this collection"
-msgstr "Lägg automatiskt till böckerna till denna samling"
+msgstr "Lï¿½gg automatiskt till bï¿½ckerna till denna samling"
 
 #
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Kunde inte öppna %s: Är en katalog."
+msgid "Could not open {}: Is a directory."
+msgstr "Kunde inte ï¿½ppna {}: ï¿½r en katalog."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Kunde inte öppna %s: Filen finns inte."
+msgid "Could not open {}: No such file."
+msgstr "Kunde inte ï¿½ppna {}: Filen finns inte."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Kunde inte öppna %s: Otillräckliga rättigheter."
+msgid "Could not open {}: Permission denied."
+msgstr "Kunde inte ï¿½ppna {}: Otillrï¿½ckliga rï¿½ttigheter."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Kunde inte öppna %s: Okänd filtyp."
+msgid "Could not open {}: Unknown file type."
+msgstr "Kunde inte ï¿½ppna {}: Okï¿½nd filtyp."
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Inga bilder i '%s'."
+msgid "No images in '{}'"
+msgstr "Inga bilder i '{}'."
 
 #
 # File: src/filehandler.py, line: 411
 #: src/filehandler.py:413
 msgid "Unknown filetype"
-msgstr "Okänd filtyp"
+msgstr "Okï¿½nd filtyp"
 
 #
 # File: src/librarybackend.py, line: 272
@@ -557,7 +557,7 @@ msgstr "Bibliotek"
 # File: src/library.py, line: 150
 #: src/library.py:150
 msgid "Rename..."
-msgstr "Döp om..."
+msgstr "Dï¿½p om..."
 
 #
 # File: src/library.py, line: 152
@@ -575,38 +575,38 @@ msgstr "Ta bort samling..."
 # File: src/library.py, line: 202
 #: src/library.py:202
 msgid "All books"
-msgstr "Alla böcker"
+msgstr "Alla bï¿½cker"
 
 #
 # File: src/library.py, line: 231
 #: src/library.py:231
 msgid "Remove collection from the library?"
-msgstr "Ta bort samling från biblioteket?"
+msgstr "Ta bort samling frï¿½n biblioteket?"
 
 #
 # File: src/library.py, line: 233
 #: src/library.py:233
 msgid "The selected collection will be removed from the library (but the books and subcollections in it will remain). Are you sure that you want to continue?"
-msgstr "Den markerade samlingen kommer att tas bort från biblioteket (men böckerna och undersamlingarna i den kommer att vara kvar). Är du säker på att du vill fortsätta?"
+msgstr "Den markerade samlingen kommer att tas bort frï¿½n biblioteket (men bï¿½ckerna och undersamlingarna i den kommer att vara kvar). ï¿½r du sï¿½ker pï¿½ att du vill fortsï¿½tta?"
 
 #
 # File: src/library.py, line: 251
 #: src/library.py:251
 msgid "Rename collection?"
-msgstr "Döp om samling?"
+msgstr "Dï¿½p om samling?"
 
 #
 # File: src/library.py, line: 253
 #: src/library.py:253
 msgid "Please enter a new name for the selected collection."
-msgstr "Ange ett nytt namn för den markerade samlingen."
+msgstr "Ange ett nytt namn fï¿½r den markerade samlingen."
 
 #
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Kunde inte ändra namnet till '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Kunde inte ï¿½ndra namnet till '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -632,72 +632,72 @@ msgstr "Rot"
 # File: src/library.py, line: 386
 #: src/library.py:386
 #, python-format
-msgid "Put the collection '%(subcollection)s' in the collection '%(supercollection)s'."
-msgstr "Lägg samlingen '%(subcollection)s' i samlingen '%(supercollection)s'."
+msgid "Put the collection '{subcollection}' in the collection '{supercollection}'."
+msgstr "Lï¿½gg samlingen '{subcollection}' i samlingen '{supercollection}'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Lägg till böcker i '%s'."
+msgid "Add books to '{}'."
+msgstr "Lï¿½gg till bï¿½cker i '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
-msgid "Move books from '%(source collection)s' to '%(destination collection)s'."
-msgstr "Flytta böcker från '%(source collection)s' till '%(destination collection)s'."
+msgid "Move books from '{source collection}' to '{destination collection}'."
+msgstr "Flytta bï¿½cker frï¿½n '{source collection}' till '{destination collection}'."
 
 #
 # File: src/library.py, line: 492
 #: src/library.py:493
 msgid "Remove from this collection"
-msgstr "Ta bort från den här samlingen"
+msgstr "Ta bort frï¿½n den hï¿½r samlingen"
 
 #
 # File: src/library.py, line: 495
 #: src/library.py:496
 msgid "Remove from the library..."
-msgstr "Ta bort från biblioteket..."
+msgstr "Ta bort frï¿½n biblioteket..."
 
 #
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Tog bort %(num)d antal böcker från '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Tog bort {num} antal bï¿½cker frï¿½n '{collection}'."
 
 #
 # File: src/library.py, line: 597
 #: src/library.py:598
 msgid "Remove books from the library?"
-msgstr "Ta bort böcker från biblioteket?"
+msgstr "Ta bort bï¿½cker frï¿½n biblioteket?"
 
 #
 # File: src/library.py, line: 599
 #: src/library.py:600
 msgid "The selected books will be removed from the library (but the original files will be untouched). Are you sure that you want to continue?"
-msgstr "De markerade böckerna kommer att tas bort från biblioteket (men originalfilerna kommer att förbli orörda). Är du säker på att du vill fortsätta?"
+msgstr "De markerade bï¿½ckerna kommer att tas bort frï¿½n biblioteket (men originalfilerna kommer att fï¿½rbli orï¿½rda). ï¿½r du sï¿½ker pï¿½ att du vill fortsï¿½tta?"
 
 #
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Tog bort %d antal böcker från biblioteket."
+msgid "Removed {} book(s) from the library."
+msgstr "Tog bort {} antal bï¿½cker frï¿½n biblioteket."
 
 #
 # File: src/library.py, line: 769
 #: src/library.py:770
 msgid "Search"
-msgstr "Sök"
+msgstr "Sï¿½k"
 
 #
 # File: src/library.py, line: 774
 #: src/library.py:775
 msgid "Display only those books that have the specified text string in their full path. The search is not case sensitive."
-msgstr "Visa endast de böcker där den angivna textsträngen förekommer i deras sökväg. Sökningen är oberoende av gemener och versaler."
+msgstr "Visa endast de bï¿½cker dï¿½r den angivna textstrï¿½ngen fï¿½rekommer i deras sï¿½kvï¿½g. Sï¿½kningen ï¿½r oberoende av gemener och versaler."
 
 #
 # File: src/library.py, line: 776
@@ -709,31 +709,31 @@ msgstr "Omslagsstorlek"
 # File: src/library.py, line: 789
 #: src/library.py:790
 msgid "Add books"
-msgstr "Lägg till böcker"
+msgstr "Lï¿½gg till bï¿½cker"
 
 #
 # File: src/library.py, line: 793
 #: src/library.py:794
 msgid "Add more books to the library."
-msgstr "Lägg till fler böcker till biblioteket."
+msgstr "Lï¿½gg till fler bï¿½cker till biblioteket."
 
 #
 # File: src/library.py, line: 795
 #: src/library.py:796
 msgid "Add collection"
-msgstr "Lägg till samling"
+msgstr "Lï¿½gg till samling"
 
 #
 # File: src/library.py, line: 800
 #: src/library.py:801
 msgid "Add a new empty collection."
-msgstr "Lägg till en ny tom samling."
+msgstr "Lï¿½gg till en ny tom samling."
 
 #
 # File: src/library.py, line: 806
 #: src/library.py:807
 msgid "Open the selected book."
-msgstr "Öppna den markerade boken."
+msgstr "ï¿½ppna den markerade boken."
 
 #
 # File: src/library.py, line: 832
@@ -741,20 +741,20 @@ msgstr "Öppna den markerade boken."
 #: src/library.py:833
 #: src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d sidor"
+msgid "{} pages"
+msgstr "{} sidor"
 
 #
 # File: src/library.py, line: 854
 #: src/library.py:855
 msgid "Add new collection?"
-msgstr "Lägg till ny samling?"
+msgstr "Lï¿½gg till ny samling?"
 
 #
 # File: src/library.py, line: 856
 #: src/library.py:857
 msgid "Please enter a name for the new collection."
-msgstr "Ange ett namn åt den nya samlingen."
+msgstr "Ange ett namn ï¿½t den nya samlingen."
 
 #
 # File: src/library.py, line: 862
@@ -766,27 +766,27 @@ msgstr "Ny samling"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Kunde inte lägga till en ny samling med namnet '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Kunde inte lï¿½gga till en ny samling med namnet '{}'."
 
 #
 # File: src/library.py, line: 910
 #: src/library.py:911
 msgid "Adding books"
-msgstr "Lägger till böcker"
+msgstr "Lï¿½gger till bï¿½cker"
 
 #
 # File: src/library.py, line: 930
 #: src/library.py:931
 msgid "Added books"
-msgstr "Tillagda böcker"
+msgstr "Tillagda bï¿½cker"
 
 #
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Lägger till '%s'..."
+msgid "Adding '{}'..."
+msgstr "Lï¿½gger till '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -798,37 +798,37 @@ msgstr "BILDSPEL"
 # File: src/preferences.py, line: 78
 #: src/preferences.py:82
 msgid "Preferences"
-msgstr "Inställningar"
+msgstr "Instï¿½llningar"
 
 #
 # File: src/preferences.py, line: 93
 #: src/preferences.py:97
 msgid "Background"
-msgstr "Bakgrundsfärg"
+msgstr "Bakgrundsfï¿½rg"
 
 #
 # File: src/preferences.py, line: 95
 #: src/preferences.py:99
 msgid "Use this colour as background"
-msgstr "Använd denna färg som bakgrundsfärg"
+msgstr "Anvï¿½nd denna fï¿½rg som bakgrundsfï¿½rg"
 
 #
 # File: src/preferences.py, line: 97
 #: src/preferences.py:101
 msgid "Always use this selected colour as the background colour."
-msgstr "Använd alltid denna valda färg som bakgrundsfärg."
+msgstr "Anvï¿½nd alltid denna valda fï¿½rg som bakgrundsfï¿½rg."
 
 #
 # File: src/preferences.py, line: 102
 #: src/preferences.py:106
 msgid "Use dynamic background colour."
-msgstr "Använd dynamisk bakgrundsfärg."
+msgstr "Anvï¿½nd dynamisk bakgrundsfï¿½rg."
 
 #
 # File: src/preferences.py, line: 106
 #: src/preferences.py:110
 msgid "Automatically pick a background colour that fits the viewed image."
-msgstr "Välj automatiskt en bakgrundsfärg som passar den visade bilden."
+msgstr "Vï¿½lj automatiskt en bakgrundsfï¿½rg som passar den visade bilden."
 
 #
 # File: src/preferences.py, line: 109
@@ -846,37 +846,37 @@ msgstr "Miniatyrbildsstorlek (i pixlar)"
 # File: src/preferences.py, line: 117
 #: src/preferences.py:121
 msgid "Show page numbers on thumbnails."
-msgstr "Visa sidonummer på miniatyrbilder."
+msgstr "Visa sidonummer pï¿½ miniatyrbilder."
 
 #
 # File: src/preferences.py, line: 124
 #: src/preferences.py:128
 msgid "Magnifying Glass"
-msgstr "Förstoringsglas"
+msgstr "Fï¿½rstoringsglas"
 
 #
 # File: src/preferences.py, line: 125
 #: src/preferences.py:129
 msgid "Magnifying glass size (in pixels)"
-msgstr "Förstoringsglasstorlek (i pixlar)"
+msgstr "Fï¿½rstoringsglasstorlek (i pixlar)"
 
 #
 # File: src/preferences.py, line: 131
 #: src/preferences.py:135
 msgid "Set the size of the magnifying glass. It is a square with a side of this many pixels."
-msgstr "Ställ in storleken på förstoringsglaset. Det är en kvadrat vars sida är så här många pixlar bred."
+msgstr "Stï¿½ll in storleken pï¿½ fï¿½rstoringsglaset. Det ï¿½r en kvadrat vars sida ï¿½r sï¿½ hï¿½r mï¿½nga pixlar bred."
 
 #
 # File: src/preferences.py, line: 133
 #: src/preferences.py:137
 msgid "Magnification factor"
-msgstr "Förstoringsfaktor"
+msgstr "Fï¿½rstoringsfaktor"
 
 #
 # File: src/preferences.py, line: 140
 #: src/preferences.py:144
 msgid "Set the magnification factor of the magnifying glass."
-msgstr "Ställ in förstoringsfaktorn för förstoringsglaset."
+msgstr "Stï¿½ll in fï¿½rstoringsfaktorn fï¿½r fï¿½rstoringsglaset."
 
 #
 # File: src/preferences.py, line: 143
@@ -888,13 +888,13 @@ msgstr "Bildskalning"
 # File: src/preferences.py, line: 144
 #: src/preferences.py:148
 msgid "Stretch small images."
-msgstr "Dra ut små bilder."
+msgstr "Dra ut smï¿½ bilder."
 
 #
 # File: src/preferences.py, line: 148
 #: src/preferences.py:152
 msgid "Stretch images to a size that is larger than their original size if the current zoom mode requests it. If this preference is unset, images are never scaled to be larger than their original size."
-msgstr "Dra ut bilder till en storlek som är större än deras originalstorlek om zoomningsläget kräver det. Om denna inställning är avaktiverad så blir bilder aldrig skalade till en storlek som övergår deras originalstorlek."
+msgstr "Dra ut bilder till en storlek som ï¿½r stï¿½rre ï¿½n deras originalstorlek om zoomningslï¿½get krï¿½ver det. Om denna instï¿½llning ï¿½r avaktiverad sï¿½ blir bilder aldrig skalade till en storlek som ï¿½vergï¿½r deras originalstorlek."
 
 #
 # File: src/preferences.py, line: 151
@@ -906,13 +906,13 @@ msgstr "Transparens"
 # File: src/preferences.py, line: 153
 #: src/preferences.py:157
 msgid "Use checkered background for transparent images."
-msgstr "Använd rutig bakgrund för transparenta bilder."
+msgstr "Anvï¿½nd rutig bakgrund fï¿½r transparenta bilder."
 
 #
 # File: src/preferences.py, line: 159
 #: src/preferences.py:163
 msgid "Use a grey checkered background for transparent images. If this preference is unset, the background is plain white instead."
-msgstr "Använd en grårutig bakgrund till transparenta bilder. Om den här inställningen är avaktiverad så används en helvit bakgrund istället."
+msgstr "Anvï¿½nd en grï¿½rutig bakgrund till transparenta bilder. Om den hï¿½r instï¿½llningen ï¿½r avaktiverad sï¿½ anvï¿½nds en helvit bakgrund istï¿½llet."
 
 #
 # File: src/preferences.py, line: 161
@@ -930,21 +930,21 @@ msgstr "Scrollning"
 # File: src/preferences.py, line: 169
 #: src/preferences.py:173
 msgid "Use smart space key scrolling."
-msgstr "Använd smart scrollning med mellanslagstangenten."
+msgstr "Anvï¿½nd smart scrollning med mellanslagstangenten."
 
 #
 # File: src/preferences.py, line: 174
 #: src/preferences.py:178
 msgid "Use smart scrolling with the space key. Normally the space key scrolls only right down (or up when shift is pressed), but with this preference set it also scrolls sideways and so tries to follow the natural reading order of the comic book."
-msgstr "Använd smart scrollning med mellanslagstangenten. Normalt så scrollar mellanslagstangenten bara rakt ner (eller upp om shift är intryckt), men med den här inställningen aktiverad så scrollar den också i sidled och försöker på så vis att följa den naturliga läsriktningen av serieboken."
+msgstr "Anvï¿½nd smart scrollning med mellanslagstangenten. Normalt sï¿½ scrollar mellanslagstangenten bara rakt ner (eller upp om shift ï¿½r intryckt), men med den hï¿½r instï¿½llningen aktiverad sï¿½ scrollar den ocksï¿½ i sidled och fï¿½rsï¿½ker pï¿½ sï¿½ vis att fï¿½lja den naturliga lï¿½sriktningen av serieboken."
 
 #: src/preferences.py:182
 msgid "Flip pages when scrolling off the edges of the page."
-msgstr "Vänd blad vid scrollning förbi sidans kanter. "
+msgstr "Vï¿½nd blad vid scrollning fï¿½rbi sidans kanter. "
 
 #: src/preferences.py:187
 msgid "Flip pages when scrolling \"off the page\" with the scroll wheel or with the arrow keys. It takes three consecutive \"steps\" with the scroll wheel or the arrow keys for the pages to be flipped."
-msgstr "Vänd blad när du scrollar \"av sidan\" med scrollhjulet eller med piltangenterna. Det krävs tre på varandra följande \"steg\" med scrollhjulet eller piltangenterna för att sidan ska vändas."
+msgstr "Vï¿½nd blad nï¿½r du scrollar \"av sidan\" med scrollhjulet eller med piltangenterna. Det krï¿½vs tre pï¿½ varandra fï¿½ljande \"steg\" med scrollhjulet eller piltangenterna fï¿½r att sidan ska vï¿½ndas."
 
 #
 # File: src/preferences.py, line: 177
@@ -952,31 +952,31 @@ msgstr "Vänd blad när du scrollar \"av sidan\" med scrollhjulet eller med piltan
 #: src/preferences.py:190
 #: src/ui.py:298
 msgid "Double page mode"
-msgstr "Dubbelsidesläge"
+msgstr "Dubbelsideslï¿½ge"
 
 #
 # File: src/preferences.py, line: 179
 #: src/preferences.py:192
 msgid "Flip two pages in double page mode."
-msgstr "Bläddra två sidor i dubbelsidesläge."
+msgstr "Blï¿½ddra tvï¿½ sidor i dubbelsideslï¿½ge."
 
 #
 # File: src/preferences.py, line: 184
 #: src/preferences.py:197
 msgid "Flip two pages, instead of one, each time we flip pages in double page mode."
-msgstr "Bläddra två sidor, istället för en, varje gång vi byter sida i dubbelsidesläge."
+msgstr "Blï¿½ddra tvï¿½ sidor, istï¿½llet fï¿½r en, varje gï¿½ng vi byter sida i dubbelsideslï¿½ge."
 
 #
 # File: src/preferences.py, line: 187
 #: src/preferences.py:200
 msgid "Show only one wide image in double page mode."
-msgstr "Visa endast en bred bild i dubbelsidesläge."
+msgstr "Visa endast en bred bild i dubbelsideslï¿½ge."
 
 #
 # File: src/preferences.py, line: 193
 #: src/preferences.py:206
 msgid "Display only one image in double page mode, if the image's width exceeds its height. The result of this is that scans that span two pages are displayed properly (i.e. alone) also in double page mode."
-msgstr "Visa endast en bild i dubbelsidesläge, om bildens bredd överstiger dess höjd. Effekten av detta är att en scan som innehåller två sidor visas ensam också i dubbelsidesläge."
+msgstr "Visa endast en bild i dubbelsideslï¿½ge, om bildens bredd ï¿½verstiger dess hï¿½jd. Effekten av detta ï¿½r att en scan som innehï¿½ller tvï¿½ sidor visas ensam ocksï¿½ i dubbelsideslï¿½ge."
 
 #
 # File: src/preferences.py, line: 196
@@ -988,49 +988,49 @@ msgstr "Filer"
 # File: src/preferences.py, line: 198
 #: src/preferences.py:211
 msgid "Automatically open the next archive."
-msgstr "Öppna automatiskt nästa arkiv."
+msgstr "ï¿½ppna automatiskt nï¿½sta arkiv."
 
 #
 # File: src/preferences.py, line: 203
 #: src/preferences.py:216
 msgid "Automatically open the next archive in the directory when flipping past the last page, or the previous archive when flipping past the first page."
-msgstr "Öppna automatiskt nästa arkiv i katalogen när vi bläddrar förbi den sista sidan, eller det föregående arkivet när vi bläddrar förbi den första sidan."
+msgstr "ï¿½ppna automatiskt nï¿½sta arkiv i katalogen nï¿½r vi blï¿½ddrar fï¿½rbi den sista sidan, eller det fï¿½regï¿½ende arkivet nï¿½r vi blï¿½ddrar fï¿½rbi den fï¿½rsta sidan."
 
 #
 # File: src/preferences.py, line: 206
 #: src/preferences.py:219
 msgid "Automatically open the last viewed file on startup."
-msgstr "Öppna automatiskt den senast lästa filen vid uppstart."
+msgstr "ï¿½ppna automatiskt den senast lï¿½sta filen vid uppstart."
 
 #
 # File: src/preferences.py, line: 211
 #: src/preferences.py:224
 msgid "Automatically open, on startup, the file that was open when Comix was last closed."
-msgstr "Öppna automatiskt, vid uppstart, den fil som var öppnad när Comix avslutades senast."
+msgstr "ï¿½ppna automatiskt, vid uppstart, den fil som var ï¿½ppnad nï¿½r Comix avslutades senast."
 
 #
 # File: src/preferences.py, line: 214
 #: src/preferences.py:227
 msgid "Store information about recently opened files."
-msgstr "Lagra information om de senast öppnade filerna."
+msgstr "Lagra information om de senast ï¿½ppnade filerna."
 
 #
 # File: src/preferences.py, line: 219
 #: src/preferences.py:232
 msgid "Add information about all files opened from within Comix to the shared recent files list."
-msgstr "Lägg till information om alla filer som öppnas inifrån Comix till den delade listan med senast öppnade filer."
+msgstr "Lï¿½gg till information om alla filer som ï¿½ppnas inifrï¿½n Comix till den delade listan med senast ï¿½ppnade filer."
 
 #
 # File: src/preferences.py, line: 222
 #: src/preferences.py:235
 msgid "Store thumbnails for opened files."
-msgstr "Lagra miniatyrbilder för öppnade filer."
+msgstr "Lagra miniatyrbilder fï¿½r ï¿½ppnade filer."
 
 #
 # File: src/preferences.py, line: 227
 #: src/preferences.py:240
 msgid "Store thumbnails for opened files according to the freedesktop.org specification. These thumbnails are shared by many other applications, such as most file managers."
-msgstr "Lagra miniatyrbilder för filer som öppnas, i enlighet med freedesktop.org-specifikationen. Dessa miniatyrbilder delas av många andra program, exempelvis de flesta filhanterare."
+msgstr "Lagra miniatyrbilder fï¿½r filer som ï¿½ppnas, i enlighet med freedesktop.org-specifikationen. Dessa miniatyrbilder delas av mï¿½nga andra program, exempelvis de flesta filhanterare."
 
 #
 # File: src/preferences.py, line: 230
@@ -1042,13 +1042,13 @@ msgstr "Cache"
 # File: src/preferences.py, line: 231
 #: src/preferences.py:244
 msgid "Use a cache to speed up browsing."
-msgstr "Använd en cache för att snabba upp bläddring."
+msgstr "Anvï¿½nd en cache fï¿½r att snabba upp blï¿½ddring."
 
 #
 # File: src/preferences.py, line: 235
 #: src/preferences.py:248
 msgid "Cache the images that are next to the currently viewed image in order to speed up browsing. Since the speed improvements are quite big, it is recommended that you have this preference set, unless you are running short on free RAM."
-msgstr "Använd en cache till att lagra bilderna intill den visade bilden, för att snabba upp bläddring. Eftersom hastighetsförbättringen är relativt stor så rekommenderas du att ha den här inställningen aktiverad, om du inte har ont om ledigt RAM-minne."
+msgstr "Anvï¿½nd en cache till att lagra bilderna intill den visade bilden, fï¿½r att snabba upp blï¿½ddring. Eftersom hastighetsfï¿½rbï¿½ttringen ï¿½r relativt stor sï¿½ rekommenderas du att ha den hï¿½r instï¿½llningen aktiverad, om du inte har ont om ledigt RAM-minne."
 
 #
 # File: src/preferences.py, line: 237
@@ -1060,31 +1060,31 @@ msgstr "Beteende"
 # File: src/preferences.py, line: 243
 #: src/preferences.py:256
 msgid "Default modes"
-msgstr "Standardlägen"
+msgstr "Standardlï¿½gen"
 
 #
 # File: src/preferences.py, line: 245
 #: src/preferences.py:258
 msgid "Use double page mode by default."
-msgstr "Använd dubbelsidesläge som standard."
+msgstr "Anvï¿½nd dubbelsideslï¿½ge som standard."
 
 #
 # File: src/preferences.py, line: 250
 #: src/preferences.py:263
 msgid "Use fullscreen by default."
-msgstr "Använd helskärm som standard."
+msgstr "Anvï¿½nd helskï¿½rm som standard."
 
 #
 # File: src/preferences.py, line: 255
 #: src/preferences.py:268
 msgid "Use manga mode by default."
-msgstr "Använd mangaläge som standard."
+msgstr "Anvï¿½nd mangalï¿½ge som standard."
 
 #
 # File: src/preferences.py, line: 260
 #: src/preferences.py:273
 msgid "Default zoom mode"
-msgstr "Standardzoomläge"
+msgstr "Standardzoomlï¿½ge"
 
 #
 # File: src/preferences.py, line: 262
@@ -1092,7 +1092,7 @@ msgstr "Standardzoomläge"
 #: src/preferences.py:275
 #: src/ui.py:290
 msgid "Best fit mode"
-msgstr "Bästa anpassningsläge"
+msgstr "Bï¿½sta anpassningslï¿½ge"
 
 #
 # File: src/preferences.py, line: 263
@@ -1100,7 +1100,7 @@ msgstr "Bästa anpassningsläge"
 #: src/preferences.py:276
 #: src/ui.py:292
 msgid "Fit width mode"
-msgstr "Breddanpassningsläge"
+msgstr "Breddanpassningslï¿½ge"
 
 #
 # File: src/preferences.py, line: 264
@@ -1108,7 +1108,7 @@ msgstr "Breddanpassningsläge"
 #: src/preferences.py:277
 #: src/ui.py:294
 msgid "Fit height mode"
-msgstr "Höjdanpassningsläge"
+msgstr "Hï¿½jdanpassningslï¿½ge"
 
 #
 # File: src/preferences.py, line: 265
@@ -1116,19 +1116,19 @@ msgstr "Höjdanpassningsläge"
 #: src/preferences.py:278
 #: src/ui.py:296
 msgid "Manual zoom mode"
-msgstr "Manuellt zoomläge"
+msgstr "Manuellt zoomlï¿½ge"
 
 #
 # File: src/preferences.py, line: 271
 #: src/preferences.py:284
 msgid "Fullscreen"
-msgstr "Helskärm"
+msgstr "Helskï¿½rm"
 
 #
 # File: src/preferences.py, line: 273
 #: src/preferences.py:286
 msgid "Automatically hide all toolbars in fullscreen."
-msgstr "Göm automatiskt alla verktygsrader i helskärmsläge."
+msgstr "Gï¿½m automatiskt alla verktygsrader i helskï¿½rmslï¿½ge."
 
 #
 # File: src/preferences.py, line: 279
@@ -1140,19 +1140,19 @@ msgstr "Bildspel"
 # File: src/preferences.py, line: 280
 #: src/preferences.py:293
 msgid "Slideshow delay (in seconds)"
-msgstr "Bildspelsfördröjning (i sekunder)"
+msgstr "Bildspelsfï¿½rdrï¿½jning (i sekunder)"
 
 #
 # File: src/preferences.py, line: 289
 #: src/preferences.py:302
 msgid "Comment extensions"
-msgstr "Kommentarsfiländelser"
+msgstr "Kommentarsfilï¿½ndelser"
 
 #
 # File: src/preferences.py, line: 295
 #: src/preferences.py:308
 msgid "Treat all files found within archives, that have one of these file endings, as comments."
-msgstr "Behandla alla filer funna i arkiv, som har en av dessa filändelser, som kommentarer."
+msgstr "Behandla alla filer funna i arkiv, som har en av dessa filï¿½ndelser, som kommentarer."
 
 #: src/preferences.py:311
 msgid "Rotation"
@@ -1182,8 +1182,8 @@ msgstr "Egenskaper"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d kommentarer"
+msgid "{} comments"
+msgstr "{} kommentarer"
 
 #
 # File: src/properties.py, line: 124
@@ -1199,7 +1199,7 @@ msgstr "Plats"
 #: src/properties.py:131
 #: src/properties.py:165
 msgid "Accessed"
-msgstr "Åtkomsttid"
+msgstr "ï¿½tkomsttid"
 
 #
 # File: src/properties.py, line: 128
@@ -1215,7 +1215,7 @@ msgstr "Modifieringstid"
 #: src/properties.py:135
 #: src/properties.py:169
 msgid "Permissions"
-msgstr "Rättigheter"
+msgstr "Rï¿½ttigheter"
 
 #
 # File: src/properties.py, line: 131
@@ -1223,7 +1223,7 @@ msgstr "Rättigheter"
 #: src/properties.py:136
 #: src/properties.py:170
 msgid "Owner"
-msgstr "Ägare"
+msgstr "ï¿½gare"
 
 #
 # File: src/properties.py, line: 135
@@ -1241,7 +1241,7 @@ msgstr "Bild"
 # File: src/thumbremover.py, line: 22
 #: src/thumbremover.py:24
 msgid "Thumbnail maintenance"
-msgstr "Miniatyrbildsunderhåll"
+msgstr "Miniatyrbildsunderhï¿½ll"
 
 #
 # File: src/thumbremover.py, line: 24
@@ -1259,7 +1259,7 @@ msgstr "Rensa ut miniatyrbilder"
 # File: src/thumbremover.py, line: 46
 #: src/thumbremover.py:48
 msgid "Thumbnails for files (such as image files and comic book archives) are stored in your home directory. Many different applications use and create these thumbnails, but sometimes thumbnails remain even though the original files have been removed - wasting space. This dialog can cleanup your stored thumbnails by removing orphaned and outdated thumbnails."
-msgstr "Miniatyrbilder för filer (såsom bildfiler och serieboksarkiv) lagras i din hemkatalog. Många olika program använder och skapar dessa miniatyrbilder, men ibland blir de kvarlämnade trots att originalfilerna har blivit raderade, och ödslar plats. Det här dialogfönstret kan rensa ut dina lagrade miniatyrbilder genom att ta bort kvarglömda och utdaterade miniatyrbilder."
+msgstr "Miniatyrbilder fï¿½r filer (sï¿½som bildfiler och serieboksarkiv) lagras i din hemkatalog. Mï¿½nga olika program anvï¿½nder och skapar dessa miniatyrbilder, men ibland blir de kvarlï¿½mnade trots att originalfilerna har blivit raderade, och ï¿½dslar plats. Det hï¿½r dialogfï¿½nstret kan rensa ut dina lagrade miniatyrbilder genom att ta bort kvarglï¿½mda och utdaterade miniatyrbilder."
 
 #
 # File: src/thumbremover.py, line: 58
@@ -1279,19 +1279,19 @@ msgstr "Totalt antal miniatyrbilder"
 #: src/thumbremover.py:70
 #: src/thumbremover.py:77
 msgid "Calculating..."
-msgstr "Beräknar..."
+msgstr "Berï¿½knar..."
 
 #
 # File: src/thumbremover.py, line: 72
 #: src/thumbremover.py:74
 msgid "Total size of thumbnails"
-msgstr "Total storlek på miniatyrbilder"
+msgstr "Total storlek pï¿½ miniatyrbilder"
 
 #
 # File: src/thumbremover.py, line: 80
 #: src/thumbremover.py:82
 msgid "Do you want to cleanup orphaned and outdated thumbnails now?"
-msgstr "Vill du rensa ut kvarglömda och utdaterade miniatyrbilder nu?"
+msgstr "Vill du rensa ut kvarglï¿½mda och utdaterade miniatyrbilder nu?"
 
 #
 # File: src/thumbremover.py, line: 116
@@ -1309,32 +1309,32 @@ msgstr "Antal borttagna miniatyrbilder"
 # File: src/thumbremover.py, line: 142
 #: src/thumbremover.py:144
 msgid "Total size of removed thumbnails"
-msgstr "Total storlek på borttagna miniatyrbilder"
+msgstr "Total storlek pï¿½ borttagna miniatyrbilder"
 
 #
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Tog bort miniatyrbild för '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Tog bort miniatyrbild fï¿½r '{}'"
 
 #
 # File: src/ui.py, line: 34
 #: src/ui.py:34
 msgid "_Next page"
-msgstr "_Nästa sida"
+msgstr "_Nï¿½sta sida"
 
 #
 # File: src/ui.py, line: 36
 #: src/ui.py:36
 msgid "_Previous page"
-msgstr "F_öregående sida"
+msgstr "F_ï¿½regï¿½ende sida"
 
 #
 # File: src/ui.py, line: 38
 #: src/ui.py:38
 msgid "_First page"
-msgstr "_Första sidan"
+msgstr "_Fï¿½rsta sidan"
 
 #
 # File: src/ui.py, line: 40
@@ -1364,7 +1364,7 @@ msgstr "O_riginalstorlek"
 # File: src/ui.py, line: 48
 #: src/ui.py:48
 msgid "_Close"
-msgstr "_Stäng"
+msgstr "_Stï¿½ng"
 
 #
 # File: src/ui.py, line: 50
@@ -1394,13 +1394,13 @@ msgstr "Rot_era 90 grader motsols"
 # File: src/ui.py, line: 58
 #: src/ui.py:58
 msgid "Fli_p horizontally"
-msgstr "S_pegelvänd horisontellt"
+msgstr "S_pegelvï¿½nd horisontellt"
 
 #
 # File: src/ui.py, line: 60
 #: src/ui.py:60
 msgid "Flip _vertically"
-msgstr "Spegelvänd _vertikalt"
+msgstr "Spegelvï¿½nd _vertikalt"
 
 #
 # File: src/ui.py, line: 62
@@ -1412,13 +1412,13 @@ msgstr "Manuell _zoom"
 # File: src/ui.py, line: 63
 #: src/ui.py:63
 msgid "Open _recent"
-msgstr "Öppna _senaste"
+msgstr "ï¿½ppna _senaste"
 
 #
 # File: src/ui.py, line: 64
 #: src/ui.py:64
 msgid "_Bookmarks"
-msgstr "_Bokmärken"
+msgstr "_Bokmï¿½rken"
 
 #
 # File: src/ui.py, line: 65
@@ -1448,13 +1448,13 @@ msgstr "_Visa"
 # File: src/ui.py, line: 69
 #: src/ui.py:69
 msgid "_Go"
-msgstr "_Gå"
+msgstr "_Gï¿½"
 
 #
 # File: src/ui.py, line: 70
 #: src/ui.py:70
 msgid "_Help"
-msgstr "_Hjälp"
+msgstr "_Hjï¿½lp"
 
 #
 # File: src/ui.py, line: 71
@@ -1466,13 +1466,13 @@ msgstr "_Transformera"
 # File: src/ui.py, line: 75
 #: src/ui.py:75
 msgid "_Fullscreen"
-msgstr "_Helskärmsläge"
+msgstr "_Helskï¿½rmslï¿½ge"
 
 #
 # File: src/ui.py, line: 77
 #: src/ui.py:77
 msgid "_Double page mode"
-msgstr "_Dubbelsidesläge"
+msgstr "_Dubbelsideslï¿½ge"
 
 #
 # File: src/ui.py, line: 79
@@ -1508,55 +1508,55 @@ msgstr "Miniat_yrbilder"
 # File: src/ui.py, line: 89
 #: src/ui.py:89
 msgid "H_ide all"
-msgstr "_Göm alla"
+msgstr "_Gï¿½m alla"
 
 #
 # File: src/ui.py, line: 91
 #: src/ui.py:91
 msgid "_Manga mode"
-msgstr "_Mangaläge"
+msgstr "_Mangalï¿½ge"
 
 #
 # File: src/ui.py, line: 93
 #: src/ui.py:93
 msgid "_Keep transformation"
-msgstr "Behåll transf_ormation"
+msgstr "Behï¿½ll transf_ormation"
 
 #
 # File: src/ui.py, line: 95
 #: src/ui.py:95
 msgid "Run _slideshow"
-msgstr "Kör _bildspel"
+msgstr "Kï¿½r _bildspel"
 
 #
 # File: src/ui.py, line: 97
 #: src/ui.py:97
 msgid "Magnifying _glass"
-msgstr "Förstorings_glas"
+msgstr "Fï¿½rstorings_glas"
 
 #
 # File: src/ui.py, line: 101
 #: src/ui.py:103
 msgid "_Best fit mode"
-msgstr "_Bästa anpassningsläge"
+msgstr "_Bï¿½sta anpassningslï¿½ge"
 
 #
 # File: src/ui.py, line: 103
 #: src/ui.py:105
 msgid "Fit _width mode"
-msgstr "Br_eddanpassningsläge"
+msgstr "Br_eddanpassningslï¿½ge"
 
 #
 # File: src/ui.py, line: 105
 #: src/ui.py:107
 msgid "Fit _height mode"
-msgstr "H_öjdanpassningsläge"
+msgstr "H_ï¿½jdanpassningslï¿½ge"
 
 #
 # File: src/ui.py, line: 107
 #: src/ui.py:109
 msgid "M_anual zoom mode"
-msgstr "M_anuellt zoomläge"
+msgstr "M_anuellt zoomlï¿½ge"
 
 #
 # File: src/ui.py, line: 113
@@ -1580,7 +1580,7 @@ msgstr "R_edigera arkiv..."
 # File: src/ui.py, line: 119
 #: src/ui.py:121
 msgid "_Open..."
-msgstr "_Öppna..."
+msgstr "_ï¿½ppna..."
 
 #
 # File: src/ui.py, line: 121
@@ -1592,19 +1592,19 @@ msgstr "_Egenskaper"
 # File: src/ui.py, line: 123
 #: src/ui.py:125
 msgid "_Enhance image..."
-msgstr "Fö_rbättra bild..."
+msgstr "Fï¿½_rbï¿½ttra bild..."
 
 #
 # File: src/ui.py, line: 126
 #: src/ui.py:128
 msgid "_Thumbnail maintenance..."
-msgstr "Minia_tyrsbildsunderhåll..."
+msgstr "Minia_tyrsbildsunderhï¿½ll..."
 
 #
 # File: src/ui.py, line: 128
 #: src/ui.py:130
 msgid "Pr_eferences"
-msgstr "Inst_ällningar"
+msgstr "Inst_ï¿½llningar"
 
 #
 # File: src/ui.py, line: 132
@@ -1616,19 +1616,19 @@ msgstr "Bib_liotek..."
 # File: src/ui.py, line: 282
 #: src/ui.py:284
 msgid "First page"
-msgstr "Första sidan"
+msgstr "Fï¿½rsta sidan"
 
 #
 # File: src/ui.py, line: 284
 #: src/ui.py:286
 msgid "Previous page"
-msgstr "Föregående sida"
+msgstr "Fï¿½regï¿½ende sida"
 
 #
 # File: src/ui.py, line: 285
 #: src/ui.py:287
 msgid "Next page"
-msgstr "Nästa sida"
+msgstr "Nï¿½sta sida"
 
 #
 # File: src/ui.py, line: 286
@@ -1640,13 +1640,13 @@ msgstr "Sista sidan"
 # File: src/ui.py, line: 297
 #: src/ui.py:299
 msgid "Manga mode"
-msgstr "Mangaläge"
+msgstr "Mangalï¿½ge"
 
 #
 # File: src/ui.py, line: 298
 #: src/ui.py:300
 msgid "Magnifying glass"
-msgstr "Förstoringsglas"
+msgstr "Fï¿½rstoringsglas"
 
 #~ msgid "Automatically rotate images according to the EXIF data."
 #~ msgstr "Rotera bilder automatiskt enligt EXIF-datan."
@@ -1654,7 +1654,7 @@ msgstr "Förstoringsglas"
 #~ "Automatically rotate images when an orientation is specified in the image "
 #~ "meta data, such as in an EXIF tag."
 #~ msgstr ""
-#~ "Rotera bilder automatiskt när en orientering finns specificerad i bildens "
+#~ "Rotera bilder automatiskt nï¿½r en orientering finns specificerad i bildens "
 #~ "metadata, exempelvis i en EXIF-tagg."
 #~ msgid ""
 #~ "Flip pages when scrolling \"off the page\" with the scroll wheel or with "

--- a/messages/sv/LC_MESSAGES/comix.po
+++ b/messages/sv/LC_MESSAGES/comix.po
@@ -1,5 +1,5 @@
 # Svensk katalog.
-# �versatt 2005-2006 av
+# Översatt 2005-2006 av
 # Pontus Ekberg <herrekberg@users.sourceforge.net>.
 #
 msgid ""
@@ -27,19 +27,19 @@ msgstr "Om"
 # File: src/about.py, line: 55
 #: src/about.py:56
 msgid "Comix is an image viewer specifically designed to handle comic books."
-msgstr "Comix �r en bildvisare som �r s�rskilt designad f�r att visa serier."
+msgstr "Comix är en bildvisare som är särskilt designad för att visa serier."
 
 #
 # File: src/about.py, line: 57
 #: src/about.py:58
 msgid "It reads ZIP, RAR and tar archives, as well as plain image files."
-msgstr "Den l�ser ZIP-, RAR- och tar-arkiv, samt vanliga bildfiler."
+msgstr "Den läser ZIP-, RAR- och tar-arkiv, samt vanliga bildfiler."
 
 #
 # File: src/about.py, line: 59
 #: src/about.py:60
 msgid "Comix is licensed under the GNU General Public License."
-msgstr "Comix �r licensierat under GNU General Public License."
+msgstr "Comix är licensierat under GNU General Public License."
 
 #
 # File: src/about.py, line: 75
@@ -52,123 +52,123 @@ msgstr "Utvecklare"
 #: src/about.py:84
 #: src/about.py:85
 msgid "Simplified Chinese translation"
-msgstr "F�renklad kinesisk �vers�ttning"
+msgstr "Förenklad kinesisk översättning"
 
 #
 # File: src/about.py, line: 78
 #: src/about.py:86
 msgid "Spanish translation"
-msgstr "Spansk �vers�ttning"
+msgstr "Spansk översättning"
 
 #
 # File: src/about.py, line: 79
 #: src/about.py:87
 msgid "Brazilian Portuguese translation"
-msgstr "Brasiliansk-portugisisk �vers�ttning"
+msgstr "Brasiliansk-portugisisk översättning"
 
 #
 # File: src/about.py, line: 81
 #: src/about.py:88
 msgid "German translation and Nautilus thumbnailer"
-msgstr "Tysk �vers�ttning och miniatyrbildsskapare f�r Nautilus"
+msgstr "Tysk översättning och miniatyrbildsskapare för Nautilus"
 
 #
 # File: src/about.py, line: 82
 #: src/about.py:89
 #: src/about.py:90
 msgid "Italian translation"
-msgstr "Italiensk �vers�ttning"
+msgstr "Italiensk översättning"
 
 #
 # File: src/about.py, line: 83
 #: src/about.py:91
 msgid "Dutch translation"
-msgstr "Nederl�ndsk �vers�ttning"
+msgstr "Nederländsk översättning"
 
 #
 # File: src/about.py, line: 84
 #: src/about.py:92
 #: src/about.py:93
 msgid "French translation"
-msgstr "Fransk �vers�ttning"
+msgstr "Fransk översättning"
 
 #
 # File: src/about.py, line: 85
 #: src/about.py:94
 #: src/about.py:95
 msgid "Polish translation"
-msgstr "Polsk �vers�ttning"
+msgstr "Polsk översättning"
 
 #
 # File: src/about.py, line: 86
 #: src/about.py:96
 msgid "Greek translation"
-msgstr "Grekisk �vers�ttning"
+msgstr "Grekisk översättning"
 
 #
 # File: src/about.py, line: 87
 #: src/about.py:97
 msgid "Catalan translation"
-msgstr "Katalansk �vers�ttning"
+msgstr "Katalansk översättning"
 
 #
 # File: src/about.py, line: 88
 #: src/about.py:98
 #: src/about.py:99
 msgid "Traditional Chinese translation"
-msgstr "Traditionell kinesisk �vers�ttning"
+msgstr "Traditionell kinesisk översättning"
 
 #
 # File: src/about.py, line: 89
 #: src/about.py:100
 msgid "Japanese translation"
-msgstr "Japansk �vers�ttning"
+msgstr "Japansk översättning"
 
 #
 # File: src/about.py, line: 90
 #: src/about.py:101
 msgid "Hungarian translation"
-msgstr "Ungersk �vers�ttning"
+msgstr "Ungersk översättning"
 
 #
 # File: src/about.py, line: 91
 #: src/about.py:102
 msgid "Russian translation"
-msgstr "Rysk �vers�ttning"
+msgstr "Rysk översättning"
 
 #
 # File: src/about.py, line: 92
 #: src/about.py:103
 msgid "Croatian translation"
-msgstr "Kroatisk �vers�ttning"
+msgstr "Kroatisk översättning"
 
 #
 # File: src/about.py, line: 93
 #: src/about.py:104
 msgid "Korean translation"
-msgstr "Koreansk �vers�ttning"
+msgstr "Koreansk översättning"
 
 #
 # File: src/about.py, line: 94
 #: src/about.py:105
 msgid "Persian translation"
-msgstr "Persisk �vers�ttning"
+msgstr "Persisk översättning"
 
 #
 # File: src/about.py, line: 95
 #: src/about.py:106
 msgid "Indonesian translation"
-msgstr "Indonesisk �vers�ttning"
+msgstr "Indonesisk översättning"
 
 #
 # File: src/about.py, line: 96
 #: src/about.py:107
 msgid "Czech translation"
-msgstr "Tjeckisk �vers�ttning"
+msgstr "Tjeckisk översättning"
 
 #: src/about.py:108
 msgid "Ukrainian translation"
-msgstr "Ukrainsk �vers�ttning"
+msgstr "Ukrainsk översättning"
 
 #
 # File: src/about.py, line: 97
@@ -192,7 +192,7 @@ msgstr "Kunde inte hitta RAR-filsuppackare!"
 # File: src/archive.py, line: 68
 #: src/archive.py:68
 msgid "You need either the <i>rar</i> or the <i>unrar</i> program installed in order to read RAR (.cbr) files."
-msgstr "Du beh�ver antingen programmet <i>rar</i> eller <i>unrar</i> installerat f�r att kunna l�sa RAR-filer (.cbr)."
+msgstr "Du behöver antingen programmet <i>rar</i> eller <i>unrar</i> installerat för att kunna läsa RAR-filer (.cbr)."
 
 #
 # File: src/archive.py, line: 301
@@ -228,37 +228,37 @@ msgstr "RAR-arkiv"
 # File: src/bookmark.py, line: 27
 #: src/bookmark.py:28
 msgid "_Add bookmark"
-msgstr "_L�gg till bokm�rke"
+msgstr "_Lägg till bokmärke"
 
 #
 # File: src/bookmark.py, line: 29
 #: src/bookmark.py:30
 msgid "_Edit bookmarks..."
-msgstr "R_edigera bokm�rken..."
+msgstr "R_edigera bokmärken..."
 
 #
 # File: src/bookmark.py, line: 31
 #: src/bookmark.py:32
 msgid "_Clear bookmarks..."
-msgstr "_T�m bokm�rken..."
+msgstr "_Töm bokmärken..."
 
 #
 # File: src/bookmark.py, line: 77
 #: src/bookmark.py:78
 msgid "Clear all bookmarks?"
-msgstr "T�m alla bokm�rken?"
+msgstr "Töm alla bokmärken?"
 
 #
 # File: src/bookmark.py, line: 79
 #: src/bookmark.py:80
 msgid "All stored bookmarks will be removed. Are you sure that you want to continue?"
-msgstr "Alla lagrade bokm�rken kommer att tas bort. �r du s�ker p� att du vill forts�tta?"
+msgstr "Alla lagrade bokmärken kommer att tas bort. Är du säker på att du vill fortsätta?"
 
 #
 # File: src/bookmark.py, line: 229
 #: src/bookmark.py:230
 msgid "Edit bookmarks"
-msgstr "Redigera bokm�rken"
+msgstr "Redigera bokmärken"
 
 #
 # File: src/bookmark.py, line: 255
@@ -287,19 +287,19 @@ msgstr "Kommentarer"
 #: src/comment.py:53
 #, python-format
 msgid "Could not read {}"
-msgstr "Kunde inte l�sa {}"
+msgstr "Kunde inte läsa {}"
 
 #
 # File: src/deprecated.py, line: 16
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
-msgstr "Det finns utdaterade filer kvarl�mnade p� din dator."
+msgstr "Det finns utdaterade filer kvarlämnade på din dator."
 
 #
 # File: src/deprecated.py, line: 22
 #: src/deprecated.py:22
 msgid "Some old files (that were used for storing preferences, the library, bookmarks etc. for older versions of Comix) were found on your computer. If you do not plan on using the older versions of Comix again, you should remove these files in order to save some disk space. Do you want these files to be removed for you now?"
-msgstr "N�gra gamla filer (som anv�ndes f�r att lagra inst�llningar, biblioteket, bokm�rken etc. f�r �ldre versioner av Comix) har hittats p� din dator. Om du inte planerar att anv�nda de �ldre versionerna av Comix igen, s� b�r du ta bort dessa filer f�r att spara diskutrymme. Vill du att dessa filer tas bort �t dig nu?"
+msgstr "Några gamla filer (som användes för att lagra inställningar, biblioteket, bokmärken etc. för äldre versioner av Comix) har hittats på din dator. Om du inte planerar att använda de äldre versionerna av Comix igen, så bör du ta bort dessa filer för att spara diskutrymme. Vill du att dessa filer tas bort åt dig nu?"
 
 #
 # File: src/edit.py, line: 28
@@ -349,13 +349,13 @@ msgstr "Arkiven sparas i ZIP-format."
 #: src/edit.py:170
 #: src/edit.py:288
 msgid "Remove from archive"
-msgstr "Ta bort fr�n arkiv"
+msgstr "Ta bort från arkiv"
 
 #
 # File: src/edit.py, line: 255
 #: src/edit.py:258
 msgid "Please note that the only files that are automatically added to this list are those files in archives that Comix recognizes as comments."
-msgstr "Notera att de enda filer som automatiskt l�ggs till i denna lista �r de filer i arkiv som Comix k�nner igen som kommentarer."
+msgstr "Notera att de enda filer som automatiskt läggs till i denna lista är de filer i arkiv som Comix känner igen som kommentarer."
 
 #
 # File: src/edit.py, line: 270
@@ -367,13 +367,13 @@ msgstr "Storlek"
 # File: src/enhance.py, line: 51
 #: src/enhance.py:51
 msgid "Enhance image"
-msgstr "F�rb�ttra bild"
+msgstr "Förbättra bild"
 
 #
 # File: src/enhance.py, line: 52
 #: src/enhance.py:52
 msgid "Defaults"
-msgstr "�terst�ll"
+msgstr "Återställ"
 
 #
 # File: src/enhance.py, line: 79
@@ -391,13 +391,13 @@ msgstr "Kontrast"
 # File: src/enhance.py, line: 101
 #: src/enhance.py:101
 msgid "Saturation"
-msgstr "F�rgm�ttnad"
+msgstr "Färgmättnad"
 
 #
 # File: src/enhance.py, line: 112
 #: src/enhance.py:112
 msgid "Sharpness"
-msgstr "Sk�rpa"
+msgstr "Skärpa"
 
 #
 # File: src/enhance.py, line: 126
@@ -409,7 +409,7 @@ msgstr "Justera kontrast automatiskt."
 # File: src/enhance.py, line: 128
 #: src/enhance.py:128
 msgid "Automatically adjust contrast (both lightness and darkness), separately for each colour band."
-msgstr "Justera kontrast automatiskt (b�de ljushet och m�rkhet), separat f�r varje f�rgkomponent."
+msgstr "Justera kontrast automatiskt (både ljushet och mörkhet), separat för varje färgkomponent."
 
 #
 # File: src/filechooser.py, line: 35
@@ -417,7 +417,7 @@ msgstr "Justera kontrast automatiskt (b�de ljushet och m�rkhet), separat f�
 #: src/filechooser.py:38
 #: src/library.py:490
 msgid "Open"
-msgstr "�ppna"
+msgstr "Öppna"
 
 #
 # File: src/filechooser.py, line: 39
@@ -460,13 +460,13 @@ msgstr "Tar-arkiv"
 #: src/filechooser.py:139
 #, python-format
 msgid "A file named '{}' already exists. Do you want to replace it?"
-msgstr "En fil med namnet '{}' finns redan. Vill du ers�tta den?"
+msgstr "En fil med namnet '{}' finns redan. Vill du ersätta den?"
 
 #
 # File: src/filechooser.py, line: 128
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
-msgstr "Ers�tts filen s� kommer dess inneh�ll att skrivas �ver."
+msgstr "Ersätts filen så kommer dess innehåll att skrivas över."
 
 #
 # File: src/filechooser.py, line: 171
@@ -496,35 +496,35 @@ msgstr "PNG-bilder"
 # File: src/filechooser.py, line: 195
 #: src/filechooser.py:231
 msgid "Automatically add the books to this collection"
-msgstr "L�gg automatiskt till b�ckerna till denna samling"
+msgstr "Lägg automatiskt till böckerna till denna samling"
 
 #
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
 msgid "Could not open {}: Is a directory."
-msgstr "Kunde inte �ppna {}: �r en katalog."
+msgstr "Kunde inte öppna {}: Är en katalog."
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
 msgid "Could not open {}: No such file."
-msgstr "Kunde inte �ppna {}: Filen finns inte."
+msgstr "Kunde inte öppna {}: Filen finns inte."
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
 msgid "Could not open {}: Permission denied."
-msgstr "Kunde inte �ppna {}: Otillr�ckliga r�ttigheter."
+msgstr "Kunde inte öppna {}: Otillräckliga rättigheter."
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
 msgid "Could not open {}: Unknown file type."
-msgstr "Kunde inte �ppna {}: Ok�nd filtyp."
+msgstr "Kunde inte öppna {}: Okänd filtyp."
 
 #
 # File: src/filehandler.py, line: 285
@@ -537,7 +537,7 @@ msgstr "Inga bilder i '{}'."
 # File: src/filehandler.py, line: 411
 #: src/filehandler.py:413
 msgid "Unknown filetype"
-msgstr "Ok�nd filtyp"
+msgstr "Okänd filtyp"
 
 #
 # File: src/librarybackend.py, line: 272
@@ -557,7 +557,7 @@ msgstr "Bibliotek"
 # File: src/library.py, line: 150
 #: src/library.py:150
 msgid "Rename..."
-msgstr "D�p om..."
+msgstr "Döp om..."
 
 #
 # File: src/library.py, line: 152
@@ -575,38 +575,38 @@ msgstr "Ta bort samling..."
 # File: src/library.py, line: 202
 #: src/library.py:202
 msgid "All books"
-msgstr "Alla b�cker"
+msgstr "Alla böcker"
 
 #
 # File: src/library.py, line: 231
 #: src/library.py:231
 msgid "Remove collection from the library?"
-msgstr "Ta bort samling fr�n biblioteket?"
+msgstr "Ta bort samling från biblioteket?"
 
 #
 # File: src/library.py, line: 233
 #: src/library.py:233
 msgid "The selected collection will be removed from the library (but the books and subcollections in it will remain). Are you sure that you want to continue?"
-msgstr "Den markerade samlingen kommer att tas bort fr�n biblioteket (men b�ckerna och undersamlingarna i den kommer att vara kvar). �r du s�ker p� att du vill forts�tta?"
+msgstr "Den markerade samlingen kommer att tas bort från biblioteket (men böckerna och undersamlingarna i den kommer att vara kvar). Är du säker på att du vill fortsätta?"
 
 #
 # File: src/library.py, line: 251
 #: src/library.py:251
 msgid "Rename collection?"
-msgstr "D�p om samling?"
+msgstr "Döp om samling?"
 
 #
 # File: src/library.py, line: 253
 #: src/library.py:253
 msgid "Please enter a new name for the selected collection."
-msgstr "Ange ett nytt namn f�r den markerade samlingen."
+msgstr "Ange ett nytt namn för den markerade samlingen."
 
 #
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
 msgid "Could not change the name to '{}'."
-msgstr "Kunde inte �ndra namnet till '{}'."
+msgstr "Kunde inte ändra namnet till '{}'."
 
 #
 # File: src/library.py, line: 275
@@ -633,71 +633,71 @@ msgstr "Rot"
 #: src/library.py:386
 #, python-format
 msgid "Put the collection '{subcollection}' in the collection '{supercollection}'."
-msgstr "L�gg samlingen '{subcollection}' i samlingen '{supercollection}'."
+msgstr "Lägg samlingen '{subcollection}' i samlingen '{supercollection}'."
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
 msgid "Add books to '{}'."
-msgstr "L�gg till b�cker i '{}'."
+msgstr "Lägg till böcker i '{}'."
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid "Move books from '{source collection}' to '{destination collection}'."
-msgstr "Flytta b�cker fr�n '{source collection}' till '{destination collection}'."
+msgstr "Flytta böcker från '{source collection}' till '{destination collection}'."
 
 #
 # File: src/library.py, line: 492
 #: src/library.py:493
 msgid "Remove from this collection"
-msgstr "Ta bort fr�n den h�r samlingen"
+msgstr "Ta bort från den här samlingen"
 
 #
 # File: src/library.py, line: 495
 #: src/library.py:496
 msgid "Remove from the library..."
-msgstr "Ta bort fr�n biblioteket..."
+msgstr "Ta bort från biblioteket..."
 
 #
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
 msgid "Removed {num} book(s) from '{collection}'."
-msgstr "Tog bort {num} antal b�cker fr�n '{collection}'."
+msgstr "Tog bort {num} antal böcker från '{collection}'."
 
 #
 # File: src/library.py, line: 597
 #: src/library.py:598
 msgid "Remove books from the library?"
-msgstr "Ta bort b�cker fr�n biblioteket?"
+msgstr "Ta bort böcker från biblioteket?"
 
 #
 # File: src/library.py, line: 599
 #: src/library.py:600
 msgid "The selected books will be removed from the library (but the original files will be untouched). Are you sure that you want to continue?"
-msgstr "De markerade b�ckerna kommer att tas bort fr�n biblioteket (men originalfilerna kommer att f�rbli or�rda). �r du s�ker p� att du vill forts�tta?"
+msgstr "De markerade böckerna kommer att tas bort från biblioteket (men originalfilerna kommer att förbli orörda). Är du säker på att du vill fortsätta?"
 
 #
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
 msgid "Removed {} book(s) from the library."
-msgstr "Tog bort {} antal b�cker fr�n biblioteket."
+msgstr "Tog bort {} antal böcker från biblioteket."
 
 #
 # File: src/library.py, line: 769
 #: src/library.py:770
 msgid "Search"
-msgstr "S�k"
+msgstr "Sök"
 
 #
 # File: src/library.py, line: 774
 #: src/library.py:775
 msgid "Display only those books that have the specified text string in their full path. The search is not case sensitive."
-msgstr "Visa endast de b�cker d�r den angivna textstr�ngen f�rekommer i deras s�kv�g. S�kningen �r oberoende av gemener och versaler."
+msgstr "Visa endast de böcker där den angivna textsträngen förekommer i deras sökväg. Sökningen är oberoende av gemener och versaler."
 
 #
 # File: src/library.py, line: 776
@@ -709,31 +709,31 @@ msgstr "Omslagsstorlek"
 # File: src/library.py, line: 789
 #: src/library.py:790
 msgid "Add books"
-msgstr "L�gg till b�cker"
+msgstr "Lägg till böcker"
 
 #
 # File: src/library.py, line: 793
 #: src/library.py:794
 msgid "Add more books to the library."
-msgstr "L�gg till fler b�cker till biblioteket."
+msgstr "Lägg till fler böcker till biblioteket."
 
 #
 # File: src/library.py, line: 795
 #: src/library.py:796
 msgid "Add collection"
-msgstr "L�gg till samling"
+msgstr "Lägg till samling"
 
 #
 # File: src/library.py, line: 800
 #: src/library.py:801
 msgid "Add a new empty collection."
-msgstr "L�gg till en ny tom samling."
+msgstr "Lägg till en ny tom samling."
 
 #
 # File: src/library.py, line: 806
 #: src/library.py:807
 msgid "Open the selected book."
-msgstr "�ppna den markerade boken."
+msgstr "Öppna den markerade boken."
 
 #
 # File: src/library.py, line: 832
@@ -748,13 +748,13 @@ msgstr "{} sidor"
 # File: src/library.py, line: 854
 #: src/library.py:855
 msgid "Add new collection?"
-msgstr "L�gg till ny samling?"
+msgstr "Lägg till ny samling?"
 
 #
 # File: src/library.py, line: 856
 #: src/library.py:857
 msgid "Please enter a name for the new collection."
-msgstr "Ange ett namn �t den nya samlingen."
+msgstr "Ange ett namn åt den nya samlingen."
 
 #
 # File: src/library.py, line: 862
@@ -767,26 +767,26 @@ msgstr "Ny samling"
 #: src/library.py:877
 #, python-format
 msgid "Could not add a new collection called '{}'."
-msgstr "Kunde inte l�gga till en ny samling med namnet '{}'."
+msgstr "Kunde inte lägga till en ny samling med namnet '{}'."
 
 #
 # File: src/library.py, line: 910
 #: src/library.py:911
 msgid "Adding books"
-msgstr "L�gger till b�cker"
+msgstr "Lägger till böcker"
 
 #
 # File: src/library.py, line: 930
 #: src/library.py:931
 msgid "Added books"
-msgstr "Tillagda b�cker"
+msgstr "Tillagda böcker"
 
 #
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
 msgid "Adding '{}'..."
-msgstr "L�gger till '{}'..."
+msgstr "Lägger till '{}'..."
 
 #
 # File: src/main.py, line: 666
@@ -798,37 +798,37 @@ msgstr "BILDSPEL"
 # File: src/preferences.py, line: 78
 #: src/preferences.py:82
 msgid "Preferences"
-msgstr "Inst�llningar"
+msgstr "Inställningar"
 
 #
 # File: src/preferences.py, line: 93
 #: src/preferences.py:97
 msgid "Background"
-msgstr "Bakgrundsf�rg"
+msgstr "Bakgrundsfärg"
 
 #
 # File: src/preferences.py, line: 95
 #: src/preferences.py:99
 msgid "Use this colour as background"
-msgstr "Anv�nd denna f�rg som bakgrundsf�rg"
+msgstr "Använd denna färg som bakgrundsfärg"
 
 #
 # File: src/preferences.py, line: 97
 #: src/preferences.py:101
 msgid "Always use this selected colour as the background colour."
-msgstr "Anv�nd alltid denna valda f�rg som bakgrundsf�rg."
+msgstr "Använd alltid denna valda färg som bakgrundsfärg."
 
 #
 # File: src/preferences.py, line: 102
 #: src/preferences.py:106
 msgid "Use dynamic background colour."
-msgstr "Anv�nd dynamisk bakgrundsf�rg."
+msgstr "Använd dynamisk bakgrundsfärg."
 
 #
 # File: src/preferences.py, line: 106
 #: src/preferences.py:110
 msgid "Automatically pick a background colour that fits the viewed image."
-msgstr "V�lj automatiskt en bakgrundsf�rg som passar den visade bilden."
+msgstr "Välj automatiskt en bakgrundsfärg som passar den visade bilden."
 
 #
 # File: src/preferences.py, line: 109
@@ -846,37 +846,37 @@ msgstr "Miniatyrbildsstorlek (i pixlar)"
 # File: src/preferences.py, line: 117
 #: src/preferences.py:121
 msgid "Show page numbers on thumbnails."
-msgstr "Visa sidonummer p� miniatyrbilder."
+msgstr "Visa sidonummer på miniatyrbilder."
 
 #
 # File: src/preferences.py, line: 124
 #: src/preferences.py:128
 msgid "Magnifying Glass"
-msgstr "F�rstoringsglas"
+msgstr "Förstoringsglas"
 
 #
 # File: src/preferences.py, line: 125
 #: src/preferences.py:129
 msgid "Magnifying glass size (in pixels)"
-msgstr "F�rstoringsglasstorlek (i pixlar)"
+msgstr "Förstoringsglasstorlek (i pixlar)"
 
 #
 # File: src/preferences.py, line: 131
 #: src/preferences.py:135
 msgid "Set the size of the magnifying glass. It is a square with a side of this many pixels."
-msgstr "St�ll in storleken p� f�rstoringsglaset. Det �r en kvadrat vars sida �r s� h�r m�nga pixlar bred."
+msgstr "Ställ in storleken på förstoringsglaset. Det är en kvadrat vars sida är så här många pixlar bred."
 
 #
 # File: src/preferences.py, line: 133
 #: src/preferences.py:137
 msgid "Magnification factor"
-msgstr "F�rstoringsfaktor"
+msgstr "Förstoringsfaktor"
 
 #
 # File: src/preferences.py, line: 140
 #: src/preferences.py:144
 msgid "Set the magnification factor of the magnifying glass."
-msgstr "St�ll in f�rstoringsfaktorn f�r f�rstoringsglaset."
+msgstr "Ställ in förstoringsfaktorn för förstoringsglaset."
 
 #
 # File: src/preferences.py, line: 143
@@ -888,13 +888,13 @@ msgstr "Bildskalning"
 # File: src/preferences.py, line: 144
 #: src/preferences.py:148
 msgid "Stretch small images."
-msgstr "Dra ut sm� bilder."
+msgstr "Dra ut små bilder."
 
 #
 # File: src/preferences.py, line: 148
 #: src/preferences.py:152
 msgid "Stretch images to a size that is larger than their original size if the current zoom mode requests it. If this preference is unset, images are never scaled to be larger than their original size."
-msgstr "Dra ut bilder till en storlek som �r st�rre �n deras originalstorlek om zoomningsl�get kr�ver det. Om denna inst�llning �r avaktiverad s� blir bilder aldrig skalade till en storlek som �verg�r deras originalstorlek."
+msgstr "Dra ut bilder till en storlek som är större än deras originalstorlek om zoomningsläget kräver det. Om denna inställning är avaktiverad så blir bilder aldrig skalade till en storlek som övergår deras originalstorlek."
 
 #
 # File: src/preferences.py, line: 151
@@ -906,13 +906,13 @@ msgstr "Transparens"
 # File: src/preferences.py, line: 153
 #: src/preferences.py:157
 msgid "Use checkered background for transparent images."
-msgstr "Anv�nd rutig bakgrund f�r transparenta bilder."
+msgstr "Använd rutig bakgrund för transparenta bilder."
 
 #
 # File: src/preferences.py, line: 159
 #: src/preferences.py:163
 msgid "Use a grey checkered background for transparent images. If this preference is unset, the background is plain white instead."
-msgstr "Anv�nd en gr�rutig bakgrund till transparenta bilder. Om den h�r inst�llningen �r avaktiverad s� anv�nds en helvit bakgrund ist�llet."
+msgstr "Använd en grårutig bakgrund till transparenta bilder. Om den här inställningen är avaktiverad så används en helvit bakgrund istället."
 
 #
 # File: src/preferences.py, line: 161
@@ -930,21 +930,21 @@ msgstr "Scrollning"
 # File: src/preferences.py, line: 169
 #: src/preferences.py:173
 msgid "Use smart space key scrolling."
-msgstr "Anv�nd smart scrollning med mellanslagstangenten."
+msgstr "Använd smart scrollning med mellanslagstangenten."
 
 #
 # File: src/preferences.py, line: 174
 #: src/preferences.py:178
 msgid "Use smart scrolling with the space key. Normally the space key scrolls only right down (or up when shift is pressed), but with this preference set it also scrolls sideways and so tries to follow the natural reading order of the comic book."
-msgstr "Anv�nd smart scrollning med mellanslagstangenten. Normalt s� scrollar mellanslagstangenten bara rakt ner (eller upp om shift �r intryckt), men med den h�r inst�llningen aktiverad s� scrollar den ocks� i sidled och f�rs�ker p� s� vis att f�lja den naturliga l�sriktningen av serieboken."
+msgstr "Använd smart scrollning med mellanslagstangenten. Normalt så scrollar mellanslagstangenten bara rakt ner (eller upp om shift är intryckt), men med den här inställningen aktiverad så scrollar den också i sidled och försöker på så vis att följa den naturliga läsriktningen av serieboken."
 
 #: src/preferences.py:182
 msgid "Flip pages when scrolling off the edges of the page."
-msgstr "V�nd blad vid scrollning f�rbi sidans kanter. "
+msgstr "Vänd blad vid scrollning förbi sidans kanter. "
 
 #: src/preferences.py:187
 msgid "Flip pages when scrolling \"off the page\" with the scroll wheel or with the arrow keys. It takes three consecutive \"steps\" with the scroll wheel or the arrow keys for the pages to be flipped."
-msgstr "V�nd blad n�r du scrollar \"av sidan\" med scrollhjulet eller med piltangenterna. Det kr�vs tre p� varandra f�ljande \"steg\" med scrollhjulet eller piltangenterna f�r att sidan ska v�ndas."
+msgstr "Vänd blad när du scrollar \"av sidan\" med scrollhjulet eller med piltangenterna. Det krävs tre på varandra följande \"steg\" med scrollhjulet eller piltangenterna för att sidan ska vändas."
 
 #
 # File: src/preferences.py, line: 177
@@ -952,31 +952,31 @@ msgstr "V�nd blad n�r du scrollar \"av sidan\" med scrollhjulet eller med pi
 #: src/preferences.py:190
 #: src/ui.py:298
 msgid "Double page mode"
-msgstr "Dubbelsidesl�ge"
+msgstr "Dubbelsidesläge"
 
 #
 # File: src/preferences.py, line: 179
 #: src/preferences.py:192
 msgid "Flip two pages in double page mode."
-msgstr "Bl�ddra tv� sidor i dubbelsidesl�ge."
+msgstr "Bläddra två sidor i dubbelsidesläge."
 
 #
 # File: src/preferences.py, line: 184
 #: src/preferences.py:197
 msgid "Flip two pages, instead of one, each time we flip pages in double page mode."
-msgstr "Bl�ddra tv� sidor, ist�llet f�r en, varje g�ng vi byter sida i dubbelsidesl�ge."
+msgstr "Bläddra två sidor, istället för en, varje gång vi byter sida i dubbelsidesläge."
 
 #
 # File: src/preferences.py, line: 187
 #: src/preferences.py:200
 msgid "Show only one wide image in double page mode."
-msgstr "Visa endast en bred bild i dubbelsidesl�ge."
+msgstr "Visa endast en bred bild i dubbelsidesläge."
 
 #
 # File: src/preferences.py, line: 193
 #: src/preferences.py:206
 msgid "Display only one image in double page mode, if the image's width exceeds its height. The result of this is that scans that span two pages are displayed properly (i.e. alone) also in double page mode."
-msgstr "Visa endast en bild i dubbelsidesl�ge, om bildens bredd �verstiger dess h�jd. Effekten av detta �r att en scan som inneh�ller tv� sidor visas ensam ocks� i dubbelsidesl�ge."
+msgstr "Visa endast en bild i dubbelsidesläge, om bildens bredd överstiger dess höjd. Effekten av detta är att en scan som innehåller två sidor visas ensam också i dubbelsidesläge."
 
 #
 # File: src/preferences.py, line: 196
@@ -988,49 +988,49 @@ msgstr "Filer"
 # File: src/preferences.py, line: 198
 #: src/preferences.py:211
 msgid "Automatically open the next archive."
-msgstr "�ppna automatiskt n�sta arkiv."
+msgstr "Öppna automatiskt nästa arkiv."
 
 #
 # File: src/preferences.py, line: 203
 #: src/preferences.py:216
 msgid "Automatically open the next archive in the directory when flipping past the last page, or the previous archive when flipping past the first page."
-msgstr "�ppna automatiskt n�sta arkiv i katalogen n�r vi bl�ddrar f�rbi den sista sidan, eller det f�reg�ende arkivet n�r vi bl�ddrar f�rbi den f�rsta sidan."
+msgstr "Öppna automatiskt nästa arkiv i katalogen när vi bläddrar förbi den sista sidan, eller det föregående arkivet när vi bläddrar förbi den första sidan."
 
 #
 # File: src/preferences.py, line: 206
 #: src/preferences.py:219
 msgid "Automatically open the last viewed file on startup."
-msgstr "�ppna automatiskt den senast l�sta filen vid uppstart."
+msgstr "Öppna automatiskt den senast lästa filen vid uppstart."
 
 #
 # File: src/preferences.py, line: 211
 #: src/preferences.py:224
 msgid "Automatically open, on startup, the file that was open when Comix was last closed."
-msgstr "�ppna automatiskt, vid uppstart, den fil som var �ppnad n�r Comix avslutades senast."
+msgstr "Öppna automatiskt, vid uppstart, den fil som var öppnad när Comix avslutades senast."
 
 #
 # File: src/preferences.py, line: 214
 #: src/preferences.py:227
 msgid "Store information about recently opened files."
-msgstr "Lagra information om de senast �ppnade filerna."
+msgstr "Lagra information om de senast öppnade filerna."
 
 #
 # File: src/preferences.py, line: 219
 #: src/preferences.py:232
 msgid "Add information about all files opened from within Comix to the shared recent files list."
-msgstr "L�gg till information om alla filer som �ppnas inifr�n Comix till den delade listan med senast �ppnade filer."
+msgstr "Lägg till information om alla filer som öppnas inifrån Comix till den delade listan med senast öppnade filer."
 
 #
 # File: src/preferences.py, line: 222
 #: src/preferences.py:235
 msgid "Store thumbnails for opened files."
-msgstr "Lagra miniatyrbilder f�r �ppnade filer."
+msgstr "Lagra miniatyrbilder för öppnade filer."
 
 #
 # File: src/preferences.py, line: 227
 #: src/preferences.py:240
 msgid "Store thumbnails for opened files according to the freedesktop.org specification. These thumbnails are shared by many other applications, such as most file managers."
-msgstr "Lagra miniatyrbilder f�r filer som �ppnas, i enlighet med freedesktop.org-specifikationen. Dessa miniatyrbilder delas av m�nga andra program, exempelvis de flesta filhanterare."
+msgstr "Lagra miniatyrbilder för filer som öppnas, i enlighet med freedesktop.org-specifikationen. Dessa miniatyrbilder delas av många andra program, exempelvis de flesta filhanterare."
 
 #
 # File: src/preferences.py, line: 230
@@ -1042,13 +1042,13 @@ msgstr "Cache"
 # File: src/preferences.py, line: 231
 #: src/preferences.py:244
 msgid "Use a cache to speed up browsing."
-msgstr "Anv�nd en cache f�r att snabba upp bl�ddring."
+msgstr "Använd en cache för att snabba upp bläddring."
 
 #
 # File: src/preferences.py, line: 235
 #: src/preferences.py:248
 msgid "Cache the images that are next to the currently viewed image in order to speed up browsing. Since the speed improvements are quite big, it is recommended that you have this preference set, unless you are running short on free RAM."
-msgstr "Anv�nd en cache till att lagra bilderna intill den visade bilden, f�r att snabba upp bl�ddring. Eftersom hastighetsf�rb�ttringen �r relativt stor s� rekommenderas du att ha den h�r inst�llningen aktiverad, om du inte har ont om ledigt RAM-minne."
+msgstr "Använd en cache till att lagra bilderna intill den visade bilden, för att snabba upp bläddring. Eftersom hastighetsförbättringen är relativt stor så rekommenderas du att ha den här inställningen aktiverad, om du inte har ont om ledigt RAM-minne."
 
 #
 # File: src/preferences.py, line: 237
@@ -1060,31 +1060,31 @@ msgstr "Beteende"
 # File: src/preferences.py, line: 243
 #: src/preferences.py:256
 msgid "Default modes"
-msgstr "Standardl�gen"
+msgstr "Standardlägen"
 
 #
 # File: src/preferences.py, line: 245
 #: src/preferences.py:258
 msgid "Use double page mode by default."
-msgstr "Anv�nd dubbelsidesl�ge som standard."
+msgstr "Använd dubbelsidesläge som standard."
 
 #
 # File: src/preferences.py, line: 250
 #: src/preferences.py:263
 msgid "Use fullscreen by default."
-msgstr "Anv�nd helsk�rm som standard."
+msgstr "Använd helskärm som standard."
 
 #
 # File: src/preferences.py, line: 255
 #: src/preferences.py:268
 msgid "Use manga mode by default."
-msgstr "Anv�nd mangal�ge som standard."
+msgstr "Använd mangaläge som standard."
 
 #
 # File: src/preferences.py, line: 260
 #: src/preferences.py:273
 msgid "Default zoom mode"
-msgstr "Standardzooml�ge"
+msgstr "Standardzoomläge"
 
 #
 # File: src/preferences.py, line: 262
@@ -1092,7 +1092,7 @@ msgstr "Standardzooml�ge"
 #: src/preferences.py:275
 #: src/ui.py:290
 msgid "Best fit mode"
-msgstr "B�sta anpassningsl�ge"
+msgstr "Bästa anpassningsläge"
 
 #
 # File: src/preferences.py, line: 263
@@ -1100,7 +1100,7 @@ msgstr "B�sta anpassningsl�ge"
 #: src/preferences.py:276
 #: src/ui.py:292
 msgid "Fit width mode"
-msgstr "Breddanpassningsl�ge"
+msgstr "Breddanpassningsläge"
 
 #
 # File: src/preferences.py, line: 264
@@ -1108,7 +1108,7 @@ msgstr "Breddanpassningsl�ge"
 #: src/preferences.py:277
 #: src/ui.py:294
 msgid "Fit height mode"
-msgstr "H�jdanpassningsl�ge"
+msgstr "Höjdanpassningsläge"
 
 #
 # File: src/preferences.py, line: 265
@@ -1116,19 +1116,19 @@ msgstr "H�jdanpassningsl�ge"
 #: src/preferences.py:278
 #: src/ui.py:296
 msgid "Manual zoom mode"
-msgstr "Manuellt zooml�ge"
+msgstr "Manuellt zoomläge"
 
 #
 # File: src/preferences.py, line: 271
 #: src/preferences.py:284
 msgid "Fullscreen"
-msgstr "Helsk�rm"
+msgstr "Helskärm"
 
 #
 # File: src/preferences.py, line: 273
 #: src/preferences.py:286
 msgid "Automatically hide all toolbars in fullscreen."
-msgstr "G�m automatiskt alla verktygsrader i helsk�rmsl�ge."
+msgstr "Göm automatiskt alla verktygsrader i helskärmsläge."
 
 #
 # File: src/preferences.py, line: 279
@@ -1140,19 +1140,19 @@ msgstr "Bildspel"
 # File: src/preferences.py, line: 280
 #: src/preferences.py:293
 msgid "Slideshow delay (in seconds)"
-msgstr "Bildspelsf�rdr�jning (i sekunder)"
+msgstr "Bildspelsfördröjning (i sekunder)"
 
 #
 # File: src/preferences.py, line: 289
 #: src/preferences.py:302
 msgid "Comment extensions"
-msgstr "Kommentarsfil�ndelser"
+msgstr "Kommentarsfiländelser"
 
 #
 # File: src/preferences.py, line: 295
 #: src/preferences.py:308
 msgid "Treat all files found within archives, that have one of these file endings, as comments."
-msgstr "Behandla alla filer funna i arkiv, som har en av dessa fil�ndelser, som kommentarer."
+msgstr "Behandla alla filer funna i arkiv, som har en av dessa filändelser, som kommentarer."
 
 #: src/preferences.py:311
 msgid "Rotation"
@@ -1199,7 +1199,7 @@ msgstr "Plats"
 #: src/properties.py:131
 #: src/properties.py:165
 msgid "Accessed"
-msgstr "�tkomsttid"
+msgstr "Åtkomsttid"
 
 #
 # File: src/properties.py, line: 128
@@ -1215,7 +1215,7 @@ msgstr "Modifieringstid"
 #: src/properties.py:135
 #: src/properties.py:169
 msgid "Permissions"
-msgstr "R�ttigheter"
+msgstr "Rättigheter"
 
 #
 # File: src/properties.py, line: 131
@@ -1223,7 +1223,7 @@ msgstr "R�ttigheter"
 #: src/properties.py:136
 #: src/properties.py:170
 msgid "Owner"
-msgstr "�gare"
+msgstr "Ägare"
 
 #
 # File: src/properties.py, line: 135
@@ -1241,7 +1241,7 @@ msgstr "Bild"
 # File: src/thumbremover.py, line: 22
 #: src/thumbremover.py:24
 msgid "Thumbnail maintenance"
-msgstr "Miniatyrbildsunderh�ll"
+msgstr "Miniatyrbildsunderhåll"
 
 #
 # File: src/thumbremover.py, line: 24
@@ -1259,7 +1259,7 @@ msgstr "Rensa ut miniatyrbilder"
 # File: src/thumbremover.py, line: 46
 #: src/thumbremover.py:48
 msgid "Thumbnails for files (such as image files and comic book archives) are stored in your home directory. Many different applications use and create these thumbnails, but sometimes thumbnails remain even though the original files have been removed - wasting space. This dialog can cleanup your stored thumbnails by removing orphaned and outdated thumbnails."
-msgstr "Miniatyrbilder f�r filer (s�som bildfiler och serieboksarkiv) lagras i din hemkatalog. M�nga olika program anv�nder och skapar dessa miniatyrbilder, men ibland blir de kvarl�mnade trots att originalfilerna har blivit raderade, och �dslar plats. Det h�r dialogf�nstret kan rensa ut dina lagrade miniatyrbilder genom att ta bort kvargl�mda och utdaterade miniatyrbilder."
+msgstr "Miniatyrbilder för filer (såsom bildfiler och serieboksarkiv) lagras i din hemkatalog. Många olika program använder och skapar dessa miniatyrbilder, men ibland blir de kvarlämnade trots att originalfilerna har blivit raderade, och ödslar plats. Det här dialogfönstret kan rensa ut dina lagrade miniatyrbilder genom att ta bort kvarglömda och utdaterade miniatyrbilder."
 
 #
 # File: src/thumbremover.py, line: 58
@@ -1279,19 +1279,19 @@ msgstr "Totalt antal miniatyrbilder"
 #: src/thumbremover.py:70
 #: src/thumbremover.py:77
 msgid "Calculating..."
-msgstr "Ber�knar..."
+msgstr "Beräknar..."
 
 #
 # File: src/thumbremover.py, line: 72
 #: src/thumbremover.py:74
 msgid "Total size of thumbnails"
-msgstr "Total storlek p� miniatyrbilder"
+msgstr "Total storlek på miniatyrbilder"
 
 #
 # File: src/thumbremover.py, line: 80
 #: src/thumbremover.py:82
 msgid "Do you want to cleanup orphaned and outdated thumbnails now?"
-msgstr "Vill du rensa ut kvargl�mda och utdaterade miniatyrbilder nu?"
+msgstr "Vill du rensa ut kvarglömda och utdaterade miniatyrbilder nu?"
 
 #
 # File: src/thumbremover.py, line: 116
@@ -1309,32 +1309,32 @@ msgstr "Antal borttagna miniatyrbilder"
 # File: src/thumbremover.py, line: 142
 #: src/thumbremover.py:144
 msgid "Total size of removed thumbnails"
-msgstr "Total storlek p� borttagna miniatyrbilder"
+msgstr "Total storlek på borttagna miniatyrbilder"
 
 #
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
 msgid "Removed thumbnail for '{}'"
-msgstr "Tog bort miniatyrbild f�r '{}'"
+msgstr "Tog bort miniatyrbild för '{}'"
 
 #
 # File: src/ui.py, line: 34
 #: src/ui.py:34
 msgid "_Next page"
-msgstr "_N�sta sida"
+msgstr "_Nästa sida"
 
 #
 # File: src/ui.py, line: 36
 #: src/ui.py:36
 msgid "_Previous page"
-msgstr "F_�reg�ende sida"
+msgstr "F_öregående sida"
 
 #
 # File: src/ui.py, line: 38
 #: src/ui.py:38
 msgid "_First page"
-msgstr "_F�rsta sidan"
+msgstr "_Första sidan"
 
 #
 # File: src/ui.py, line: 40
@@ -1364,7 +1364,7 @@ msgstr "O_riginalstorlek"
 # File: src/ui.py, line: 48
 #: src/ui.py:48
 msgid "_Close"
-msgstr "_St�ng"
+msgstr "_Stäng"
 
 #
 # File: src/ui.py, line: 50
@@ -1394,13 +1394,13 @@ msgstr "Rot_era 90 grader motsols"
 # File: src/ui.py, line: 58
 #: src/ui.py:58
 msgid "Fli_p horizontally"
-msgstr "S_pegelv�nd horisontellt"
+msgstr "S_pegelvänd horisontellt"
 
 #
 # File: src/ui.py, line: 60
 #: src/ui.py:60
 msgid "Flip _vertically"
-msgstr "Spegelv�nd _vertikalt"
+msgstr "Spegelvänd _vertikalt"
 
 #
 # File: src/ui.py, line: 62
@@ -1412,13 +1412,13 @@ msgstr "Manuell _zoom"
 # File: src/ui.py, line: 63
 #: src/ui.py:63
 msgid "Open _recent"
-msgstr "�ppna _senaste"
+msgstr "Öppna _senaste"
 
 #
 # File: src/ui.py, line: 64
 #: src/ui.py:64
 msgid "_Bookmarks"
-msgstr "_Bokm�rken"
+msgstr "_Bokmärken"
 
 #
 # File: src/ui.py, line: 65
@@ -1448,13 +1448,13 @@ msgstr "_Visa"
 # File: src/ui.py, line: 69
 #: src/ui.py:69
 msgid "_Go"
-msgstr "_G�"
+msgstr "_Gå"
 
 #
 # File: src/ui.py, line: 70
 #: src/ui.py:70
 msgid "_Help"
-msgstr "_Hj�lp"
+msgstr "_Hjälp"
 
 #
 # File: src/ui.py, line: 71
@@ -1466,13 +1466,13 @@ msgstr "_Transformera"
 # File: src/ui.py, line: 75
 #: src/ui.py:75
 msgid "_Fullscreen"
-msgstr "_Helsk�rmsl�ge"
+msgstr "_Helskärmsläge"
 
 #
 # File: src/ui.py, line: 77
 #: src/ui.py:77
 msgid "_Double page mode"
-msgstr "_Dubbelsidesl�ge"
+msgstr "_Dubbelsidesläge"
 
 #
 # File: src/ui.py, line: 79
@@ -1508,55 +1508,55 @@ msgstr "Miniat_yrbilder"
 # File: src/ui.py, line: 89
 #: src/ui.py:89
 msgid "H_ide all"
-msgstr "_G�m alla"
+msgstr "_Göm alla"
 
 #
 # File: src/ui.py, line: 91
 #: src/ui.py:91
 msgid "_Manga mode"
-msgstr "_Mangal�ge"
+msgstr "_Mangaläge"
 
 #
 # File: src/ui.py, line: 93
 #: src/ui.py:93
 msgid "_Keep transformation"
-msgstr "Beh�ll transf_ormation"
+msgstr "Behåll transf_ormation"
 
 #
 # File: src/ui.py, line: 95
 #: src/ui.py:95
 msgid "Run _slideshow"
-msgstr "K�r _bildspel"
+msgstr "Kör _bildspel"
 
 #
 # File: src/ui.py, line: 97
 #: src/ui.py:97
 msgid "Magnifying _glass"
-msgstr "F�rstorings_glas"
+msgstr "Förstorings_glas"
 
 #
 # File: src/ui.py, line: 101
 #: src/ui.py:103
 msgid "_Best fit mode"
-msgstr "_B�sta anpassningsl�ge"
+msgstr "_Bästa anpassningsläge"
 
 #
 # File: src/ui.py, line: 103
 #: src/ui.py:105
 msgid "Fit _width mode"
-msgstr "Br_eddanpassningsl�ge"
+msgstr "Br_eddanpassningsläge"
 
 #
 # File: src/ui.py, line: 105
 #: src/ui.py:107
 msgid "Fit _height mode"
-msgstr "H_�jdanpassningsl�ge"
+msgstr "H_öjdanpassningsläge"
 
 #
 # File: src/ui.py, line: 107
 #: src/ui.py:109
 msgid "M_anual zoom mode"
-msgstr "M_anuellt zooml�ge"
+msgstr "M_anuellt zoomläge"
 
 #
 # File: src/ui.py, line: 113
@@ -1580,7 +1580,7 @@ msgstr "R_edigera arkiv..."
 # File: src/ui.py, line: 119
 #: src/ui.py:121
 msgid "_Open..."
-msgstr "_�ppna..."
+msgstr "_Öppna..."
 
 #
 # File: src/ui.py, line: 121
@@ -1592,19 +1592,19 @@ msgstr "_Egenskaper"
 # File: src/ui.py, line: 123
 #: src/ui.py:125
 msgid "_Enhance image..."
-msgstr "F�_rb�ttra bild..."
+msgstr "Fö_rbättra bild..."
 
 #
 # File: src/ui.py, line: 126
 #: src/ui.py:128
 msgid "_Thumbnail maintenance..."
-msgstr "Minia_tyrsbildsunderh�ll..."
+msgstr "Minia_tyrsbildsunderhåll..."
 
 #
 # File: src/ui.py, line: 128
 #: src/ui.py:130
 msgid "Pr_eferences"
-msgstr "Inst_�llningar"
+msgstr "Inst_ällningar"
 
 #
 # File: src/ui.py, line: 132
@@ -1616,19 +1616,19 @@ msgstr "Bib_liotek..."
 # File: src/ui.py, line: 282
 #: src/ui.py:284
 msgid "First page"
-msgstr "F�rsta sidan"
+msgstr "Första sidan"
 
 #
 # File: src/ui.py, line: 284
 #: src/ui.py:286
 msgid "Previous page"
-msgstr "F�reg�ende sida"
+msgstr "Föregående sida"
 
 #
 # File: src/ui.py, line: 285
 #: src/ui.py:287
 msgid "Next page"
-msgstr "N�sta sida"
+msgstr "Nästa sida"
 
 #
 # File: src/ui.py, line: 286
@@ -1640,13 +1640,13 @@ msgstr "Sista sidan"
 # File: src/ui.py, line: 297
 #: src/ui.py:299
 msgid "Manga mode"
-msgstr "Mangal�ge"
+msgstr "Mangaläge"
 
 #
 # File: src/ui.py, line: 298
 #: src/ui.py:300
 msgid "Magnifying glass"
-msgstr "F�rstoringsglas"
+msgstr "Förstoringsglas"
 
 #~ msgid "Automatically rotate images according to the EXIF data."
 #~ msgstr "Rotera bilder automatiskt enligt EXIF-datan."
@@ -1654,7 +1654,7 @@ msgstr "F�rstoringsglas"
 #~ "Automatically rotate images when an orientation is specified in the image "
 #~ "meta data, such as in an EXIF tag."
 #~ msgstr ""
-#~ "Rotera bilder automatiskt n�r en orientering finns specificerad i bildens "
+#~ "Rotera bilder automatiskt när en orientering finns specificerad i bildens "
 #~ "metadata, exempelvis i en EXIF-tagg."
 #~ msgid ""
 #~ "Flip pages when scrolling \"off the page\" with the scroll wheel or with "

--- a/messages/uk/LC_MESSAGES/comix.po
+++ b/messages/uk/LC_MESSAGES/comix.po
@@ -193,8 +193,8 @@ msgstr "Коментарі"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "Не можу прочитати %s"
+msgid "Could not read {}"
+msgstr "Не можу прочитати {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -324,8 +324,8 @@ msgstr "Tar архіви"
 
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "Файл з ім’ям '%s' вже існує. Хочете його замінити?"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "Файл з ім’ям '{}' вже існує. Хочете його замінити?"
 
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
@@ -349,28 +349,28 @@ msgstr "Автоматично додати книжки до цієї коле�
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "Не можу відкрити %s: Є каталогом."
+msgid "Could not open {}: Is a directory."
+msgstr "Не можу відкрити {}: Є каталогом."
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "Не можу відкрити %s: Нема такого файла."
+msgid "Could not open {}: No such file."
+msgstr "Не можу відкрити {}: Нема такого файла."
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "Не можу відкрити %s: Доступ заборонено."
+msgid "Could not open {}: Permission denied."
+msgstr "Не можу відкрити {}: Доступ заборонено."
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "Не можу відкрити %s: Невідомий тип файлу"
+msgid "Could not open {}: Unknown file type."
+msgstr "Не можу відкрити {}: Невідомий тип файлу"
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "Немає зображень у '%s'"
+msgid "No images in '{}'"
+msgstr "Немає зображень у '{}'"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -422,8 +422,8 @@ msgstr "Будь ласка введіть нове ім’я для обран�
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "Не можу змінити ім’я на '%s'."
+msgid "Could not change the name to '{}'."
+msgstr "Не можу змінити ім’я на '{}'."
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
@@ -440,22 +440,22 @@ msgstr "Корінь"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
 msgstr ""
-"Покласти колекцію '%(subcollection)s' в колекцію '%(supercollection)s'."
+"Покласти колекцію '{subcollection}' в колекцію '{supercollection}'."
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "Додати книжки до '%s'."
+msgid "Add books to '{}'."
+msgstr "Додати книжки до '{}'."
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
+"Move books from '{source collection}' to '{destination collection}'."
 msgstr ""
-"Перемістити книжки з '%(source collection)s' до '%(destination collection)s'."
+"Перемістити книжки з '{source collection}' до '{destination collection}'."
 
 #: src/library.py:493
 msgid "Remove from this collection"
@@ -467,8 +467,8 @@ msgstr "Видалити з бібліотеки…"
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "Видалено %(num)d книг(а, и) з '%(collection)s'."
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "Видалено {num} книг(а, и) з '{collection}'."
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -484,8 +484,8 @@ msgstr ""
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "Видалено %d книг(а, и) з бібліотеки."
+msgid "Removed {} book(s) from the library."
+msgstr "Видалено {} книг(а, и) з бібліотеки."
 
 #: src/library.py:770
 msgid "Search"
@@ -525,8 +525,8 @@ msgstr "Відкрити обрану книгу."
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d сторінок"
+msgid "{} pages"
+msgstr "{} сторінок"
 
 #: src/library.py:855
 msgid "Add new collection?"
@@ -542,8 +542,8 @@ msgstr "Нова колекція"
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "Не можу додати нову колекцію з ім’ям '%s'."
+msgid "Could not add a new collection called '{}'."
+msgstr "Не можу додати нову колекцію з ім’ям '{}'."
 
 #: src/library.py:911
 msgid "Adding books"
@@ -555,8 +555,8 @@ msgstr "Книжки додані"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "Додаю '%s'…"
+msgid "Adding '{}'..."
+msgstr "Додаю '{}'…"
 
 #: src/main.py:704
 msgid "SLIDESHOW"
@@ -885,8 +885,8 @@ msgstr "Властивості"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d коментар(я, ів)"
+msgid "{} comments"
+msgstr "{} коментар(я, ів)"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -976,8 +976,8 @@ msgstr "Загальний розмір видалених мініатюр"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "Видалена мініатюра для '%s'"
+msgid "Removed thumbnail for '{}'"
+msgstr "Видалена мініатюра для '{}'"
 
 #: src/ui.py:34
 msgid "_Next page"

--- a/messages/zh_CN/LC_MESSAGES/comix.po
+++ b/messages/zh_CN/LC_MESSAGES/comix.po
@@ -286,8 +286,8 @@ msgstr "注释"
 # File: src/comment.py, line: 53
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "无法读取%s"
+msgid "Could not read {}"
+msgstr "无法读取{}"
 
 #
 # File: src/deprecated.py, line: 16
@@ -469,8 +469,8 @@ msgstr "Tar文件包"
 # File: src/filechooser.py, line: 125
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "名为“%s”的文件已经存在，你想要覆盖它吗？"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "名为“{}”的文件已经存在，你想要覆盖它吗？"
 
 #
 # File: src/filechooser.py, line: 128
@@ -509,36 +509,36 @@ msgstr "自动添加书到这个收藏中"
 # File: src/filehandler.py, line: 209
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "无法打开%s：它是一个目录。"
+msgid "Could not open {}: Is a directory."
+msgstr "无法打开{}：它是一个目录。"
 
 #
 # File: src/filehandler.py, line: 213
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "无法打开%s：没有这个文件。"
+msgid "Could not open {}: No such file."
+msgstr "无法打开{}：没有这个文件。"
 
 #
 # File: src/filehandler.py, line: 217
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "无法打开%s：权限不足。"
+msgid "Could not open {}: Permission denied."
+msgstr "无法打开{}：权限不足。"
 
 #
 # File: src/filehandler.py, line: 222
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "无法打开%s：未知的文件格式。"
+msgid "Could not open {}: Unknown file type."
+msgstr "无法打开{}：未知的文件格式。"
 
 #
 # File: src/filehandler.py, line: 285
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "“%s”中没有图像文件"
+msgid "No images in '{}'"
+msgstr "“{}”中没有图像文件"
 
 #
 # File: src/filehandler.py, line: 411
@@ -613,8 +613,8 @@ msgstr "请输入收藏要修改成的名称。"
 # File: src/library.py, line: 271
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "无法修改名称为“%s”。"
+msgid "Could not change the name to '{}'."
+msgstr "无法修改名称为“{}”。"
 
 #
 # File: src/library.py, line: 275
@@ -640,24 +640,24 @@ msgstr "根"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "把收藏“%(subcollection)s”放入收藏“%(supercollection)s”中。"
+msgstr "把收藏“{subcollection}”放入收藏“{supercollection}”中。"
 
 #
 # File: src/library.py, line: 407
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "添加书到“%s”中。"
+msgid "Add books to '{}'."
+msgstr "添加书到“{}”中。"
 
 #
 # File: src/library.py, line: 411
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
-msgstr "把书从“%(source collection)s”移动到“%(destination collection)s”中。"
+"Move books from '{source collection}' to '{destination collection}'."
+msgstr "把书从“{source collection}”移动到“{destination collection}”中。"
 
 #
 # File: src/library.py, line: 492
@@ -675,8 +675,8 @@ msgstr "从收藏库中删除…"
 # File: src/library.py, line: 588
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "从“%(collection)s”中删除了%(num)d本书。"
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "从“{collection}”中删除了{num}本书。"
 
 #
 # File: src/library.py, line: 597
@@ -696,8 +696,8 @@ msgstr "从收藏库中删除选中的书（不会影响原始文件）。你确
 # File: src/library.py, line: 609
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "从收藏库中删除了%d本书。"
+msgid "Removed {} book(s) from the library."
+msgstr "从收藏库中删除了{}本书。"
 
 #
 # File: src/library.py, line: 769
@@ -754,8 +754,8 @@ msgstr "打开选中的书。"
 # File: src/properties.py, line: 113
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "共%d页"
+msgid "{} pages"
+msgstr "共{}页"
 
 #
 # File: src/library.py, line: 854
@@ -779,8 +779,8 @@ msgstr "新收藏"
 # File: src/library.py, line: 876
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "无法添加名称为“%s”的新收藏。"
+msgid "Could not add a new collection called '{}'."
+msgstr "无法添加名称为“{}”的新收藏。"
 
 #
 # File: src/library.py, line: 910
@@ -798,8 +798,8 @@ msgstr "已经添加的书"
 # File: src/library.py, line: 952
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "正在添加“%s”…"
+msgid "Adding '{}'..."
+msgstr "正在添加“{}”…"
 
 #
 # File: src/main.py, line: 666
@@ -1238,8 +1238,8 @@ msgstr "属性"
 # File: src/properties.py, line: 114
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d 个注释"
+msgid "{} comments"
+msgstr "{} 个注释"
 
 #
 # File: src/properties.py, line: 124
@@ -1373,8 +1373,8 @@ msgstr "删除缩略图总大小"
 # File: src/thumbremover.py, line: 193
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "删除“%s”的缩略图"
+msgid "Removed thumbnail for '{}'"
+msgstr "删除“{}”的缩略图"
 
 #
 # File: src/ui.py, line: 34

--- a/messages/zh_TW/LC_MESSAGES/comix.po
+++ b/messages/zh_TW/LC_MESSAGES/comix.po
@@ -198,8 +198,8 @@ msgstr "註解"
 
 #: src/comment.py:53
 #, python-format
-msgid "Could not read %s"
-msgstr "無法讀取 %s"
+msgid "Could not read {}"
+msgstr "無法讀取 {}"
 
 #: src/deprecated.py:16
 msgid "There are deprecated files left on your computer."
@@ -323,8 +323,8 @@ msgstr "TAR 壓縮檔"
 
 #: src/filechooser.py:139
 #, python-format
-msgid "A file named '%s' already exists. Do you want to replace it?"
-msgstr "檔案 %s 已存在，您要替換掉它嗎？"
+msgid "A file named '{}' already exists. Do you want to replace it?"
+msgstr "檔案 {} 已存在，您要替換掉它嗎？"
 
 #: src/filechooser.py:142
 msgid "Replacing it will overwrite its contents."
@@ -348,28 +348,28 @@ msgstr "自動將此書籍加入收藏"
 
 #: src/filehandler.py:209
 #, python-format
-msgid "Could not open %s: Is a directory."
-msgstr "無法開啟 %s：它是目錄。"
+msgid "Could not open {}: Is a directory."
+msgstr "無法開啟 {}：它是目錄。"
 
 #: src/filehandler.py:213
 #, python-format
-msgid "Could not open %s: No such file."
-msgstr "無法開啟 %s：找不到檔案。"
+msgid "Could not open {}: No such file."
+msgstr "無法開啟 {}：找不到檔案。"
 
 #: src/filehandler.py:217
 #, python-format
-msgid "Could not open %s: Permission denied."
-msgstr "無法開啟 %s：沒有權限。"
+msgid "Could not open {}: Permission denied."
+msgstr "無法開啟 {}：沒有權限。"
 
 #: src/filehandler.py:222
 #, python-format
-msgid "Could not open %s: Unknown file type."
-msgstr "無法開啟 %s：不明的檔案類型。"
+msgid "Could not open {}: Unknown file type."
+msgstr "無法開啟 {}：不明的檔案類型。"
 
 #: src/filehandler.py:285
 #, python-format
-msgid "No images in '%s'"
-msgstr "%s 內沒有圖片"
+msgid "No images in '{}'"
+msgstr "{} 內沒有圖片"
 
 #: src/filehandler.py:413
 msgid "Unknown filetype"
@@ -419,8 +419,8 @@ msgstr "請輸入此收藏的新名稱。"
 
 #: src/library.py:271
 #, python-format
-msgid "Could not change the name to '%s'."
-msgstr "無法變更名稱為「%s」。"
+msgid "Could not change the name to '{}'."
+msgstr "無法變更名稱為「{}」。"
 
 #: src/library.py:275 src/library.py:882
 msgid "A collection by that name already exists."
@@ -437,20 +437,20 @@ msgstr "Root"
 #: src/library.py:386
 #, python-format
 msgid ""
-"Put the collection '%(subcollection)s' in the collection '%(supercollection)"
+"Put the collection '{subcollection}' in the collection '{supercollection}"
 "s'."
-msgstr "將收藏 %(subcollection)s 放到 %(supercollection)s 。"
+msgstr "將收藏 {subcollection} 放到 {supercollection} 。"
 
 #: src/library.py:407
 #, python-format
-msgid "Add books to '%s'."
-msgstr "將書籍加入 %s。"
+msgid "Add books to '{}'."
+msgstr "將書籍加入 {}。"
 
 #: src/library.py:411
 #, python-format
 msgid ""
-"Move books from '%(source collection)s' to '%(destination collection)s'."
-msgstr "將書籍從 %(source collection)s 移到 %(destination collection)s 。"
+"Move books from '{source collection}' to '{destination collection}'."
+msgstr "將書籍從 {source collection} 移到 {destination collection} 。"
 
 #: src/library.py:493
 msgid "Remove from this collection"
@@ -462,8 +462,8 @@ msgstr "從此收藏庫移除..."
 
 #: src/library.py:589
 #, python-format
-msgid "Removed %(num)d book(s) from '%(collection)s'."
-msgstr "已移除 %(num)d 本 %(collection)s 收藏的書籍。"
+msgid "Removed {num} book(s) from '{collection}'."
+msgstr "已移除 {num} 本 {collection} 收藏的書籍。"
 
 #: src/library.py:598
 msgid "Remove books from the library?"
@@ -477,8 +477,8 @@ msgstr "這些書籍將從收藏庫中移除，但原始檔案不會受影響。
 
 #: src/library.py:610
 #, python-format
-msgid "Removed %d book(s) from the library."
-msgstr "已從收藏庫移除 %d 本書籍。"
+msgid "Removed {} book(s) from the library."
+msgstr "已從收藏庫移除 {} 本書籍。"
 
 #: src/library.py:770
 msgid "Search"
@@ -516,8 +516,8 @@ msgstr "開啟選取的書籍。"
 
 #: src/library.py:833 src/properties.py:118
 #, python-format
-msgid "%d pages"
-msgstr "%d 頁"
+msgid "{} pages"
+msgstr "{} 頁"
 
 #: src/library.py:855
 msgid "Add new collection?"
@@ -533,8 +533,8 @@ msgstr "新收藏"
 
 #: src/library.py:877
 #, python-format
-msgid "Could not add a new collection called '%s'."
-msgstr "無法新增收藏 %s 。"
+msgid "Could not add a new collection called '{}'."
+msgstr "無法新增收藏 {} 。"
 
 #: src/library.py:911
 msgid "Adding books"
@@ -546,8 +546,8 @@ msgstr "已新增書籍"
 
 #: src/library.py:953
 #, python-format
-msgid "Adding '%s'..."
-msgstr "正在新增 %s ..."
+msgid "Adding '{}'..."
+msgstr "正在新增 {} ..."
 
 #: src/main.py:704
 msgid "SLIDESHOW"
@@ -856,8 +856,8 @@ msgstr "屬性"
 
 #: src/properties.py:119
 #, python-format
-msgid "%d comments"
-msgstr "%d 個註解"
+msgid "{} comments"
+msgstr "{} 個註解"
 
 #: src/properties.py:129 src/properties.py:164
 msgid "Location"
@@ -945,8 +945,8 @@ msgstr "已移除的縮圖總大小"
 
 #: src/thumbremover.py:195
 #, python-format
-msgid "Removed thumbnail for '%s'"
-msgstr "已移除 %s 的縮圖"
+msgid "Removed thumbnail for '{}'"
+msgstr "已移除 {} 的縮圖"
 
 #: src/ui.py:34
 msgid "_Next page"

--- a/src/about.py
+++ b/src/about.py
@@ -11,7 +11,7 @@ from PIL import Image
 from src import constants
 from src import labels
 
-ImageVersion = "Pillow-%s" % Image.PILLOW_VERSION
+ImageVersion = "Pillow-{}".format(Image.PILLOW_VERSION)
 
 _dialog = None
 
@@ -71,7 +71,7 @@ class _AboutDialog(gtk.Dialog):
                 '<small>Copyright © 2014-2017 Sergey Dryabzhinsky\n\n' +
                 'sergey.dryabzhinksy@gmail.com\n' +
                 'https://github.com/sergey-dryabzhinksy/Comix</small>\n' +
-                '\n' + _('Image processing library') + ': %s\n' % ImageVersion
+                '\n' + _('Image processing library') + ': {}\n'.format(ImageVersion)
         )
         box.pack_start(label, True, True, 0)
         label.set_justify(gtk.JUSTIFY_CENTER)
@@ -120,7 +120,7 @@ class _AboutDialog(gtk.Dialog):
                 ('Олександр Заяц', _('Ukrainian translation')),
                 ('Roxerio Roxo Carrillo', _('Galician translation')),
                 ('Victor Castillejo', _('Icon design'))):
-            name_label = labels.BoldLabel('%s:' % nice_person)
+            name_label = labels.BoldLabel('{}:'.format(nice_person))
             name_label.set_alignment(1.0, 1.0)
             left_box.pack_start(name_label, True, True)
             desc_label = gtk.Label(description)

--- a/src/archive.py
+++ b/src/archive.py
@@ -421,10 +421,9 @@ class Packer(object):
             print('! Could not create archive {}'.format(self._archive_path))
             return
         used_names = []
-        pattern = '%%0%dd - %s%%s' % (len(str(len(self._image_files))),
-                                      self._base_name)
+        pattern = '{{:0{}d}} - {}{{}}'.format(len(str(len(self._image_files))), self._base_name)
         for i, path in enumerate(self._image_files):
-            filename = pattern % (i + 1, os.path.splitext(path)[1])
+            filename = pattern.format(i + 1, os.path.splitext(path)[1])
             try:
                 zfile.write(path, filename, zipfile.ZIP_STORED)
             except Exception:
@@ -439,7 +438,7 @@ class Packer(object):
         for path in self._other_files:
             filename = os.path.basename(path)
             while filename in used_names:
-                filename = '_%s' % filename
+                filename = '_{}'.format(filename)
             try:
                 zfile.write(path, filename, zipfile.ZIP_DEFLATED)
             except Exception:

--- a/src/bookmark.py
+++ b/src/bookmark.py
@@ -117,7 +117,7 @@ class _Bookmark(gtk.ImageMenuItem):
         self.connect('activate', self._load)
 
     def __str__(self):
-        return '%s, (%d / %d)' % (self._name, self._page, self._numpages)
+        return '{}, ({:d} / {:d})'.format(self._name, self._page, self._numpages)
 
     def _load(self, *args):
         """Open the file and page the bookmark represents."""
@@ -133,7 +133,7 @@ class _Bookmark(gtk.ImageMenuItem):
         """
         stock = self.get_image().get_stock()
         pixbuf = self.render_icon(*stock)
-        page = '%d / %d' % (self._page, self._numpages)
+        page = '{:d} / {:d}'.format(self._page, self._numpages)
         return pixbuf, self._name, page, self
 
     def pack(self):

--- a/src/comment.py
+++ b/src/comment.py
@@ -57,7 +57,7 @@ class _CommentsDialog(gtk.Dialog):
             name = os.path.basename(window.file_handler.get_comment_name(num))
             text = window.file_handler.get_comment_text(num)
             if text is None:
-                text = _('Could not read {}').format(path)
+                text = _('Could not read {}').format(num)
             text_buffer = gtk.TextBuffer(tag_table)
             text_buffer.set_text(encoding.to_unicode(text))
             text_buffer.apply_tag(tag, *text_buffer.get_bounds())

--- a/src/comment.py
+++ b/src/comment.py
@@ -57,7 +57,7 @@ class _CommentsDialog(gtk.Dialog):
             name = os.path.basename(window.file_handler.get_comment_name(num))
             text = window.file_handler.get_comment_text(num)
             if text is None:
-                text = _('Could not read %s') % path
+                text = _('Could not read {}').format(path)
             text_buffer = gtk.TextBuffer(tag_table)
             text_buffer.set_text(encoding.to_unicode(text))
             text_buffer.apply_tag(tag, *text_buffer.get_bounds())

--- a/src/edit.py
+++ b/src/edit.py
@@ -85,7 +85,7 @@ class _EditArchiveDialog(gtk.Dialog):
         other_files = self._other_area.get_file_listing()
         try:
             tmp_path = tempfile.mkstemp(
-                    suffix='.%s' % os.path.basename(archive_path),
+                    suffix='.{}'.format(os.path.basename(archive_path)),
                     prefix='tmp.', dir=os.path.dirname(archive_path))[1]
             fail = False
         except:
@@ -116,10 +116,8 @@ class _EditArchiveDialog(gtk.Dialog):
                     gtk.FILE_CHOOSER_ACTION_SAVE)
             src_path = self.file_handler.get_path_to_base()
             dialog.set_current_directory(os.path.dirname(src_path))
-            dialog.set_save_name('%s.cbz' % os.path.splitext(
-                    os.path.basename(src_path))[0])
-            dialog.filechooser.set_extra_widget(gtk.Label(
-                    _('Archives are stored as ZIP files.')))
+            dialog.set_save_name('{}.cbz'.format(os.path.splitext(os.path.basename(src_path))[0]))
+            dialog.filechooser.set_extra_widget(gtk.Label(_('Archives are stored as ZIP files.')))
             dialog.run()
             paths = dialog.get_paths()
             dialog.destroy()
@@ -297,12 +295,12 @@ class _OtherArea(gtk.VBox):
         """Load all comments in the archive."""
         for num in range(1, self._edit_dialog.file_handler.get_number_of_comments() + 1):
             path = self._edit_dialog.file_handler.get_comment_name(num)
-            size = '%.1f KiB' % (os.stat(path).st_size / 1024.0)
+            size = '{:.1f} KiB'.format(os.stat(path).st_size / 1024.0)
             self._liststore.append([os.path.basename(path), size, path])
 
     def add_extra_file(self, path):
         """Add an extra imported file (at <path>) to the list."""
-        size = '%.1f KiB' % (os.stat(path).st_size / 1024.0)
+        size = '{:.1f} KiB'.format(os.stat(path).st_size / 1024.0)
         self._liststore.append([os.path.basename(path), size, path])
 
     def get_file_listing(self):

--- a/src/filechooser.py
+++ b/src/filechooser.py
@@ -133,10 +133,12 @@ class _ComicFileChooserDialog(gtk.Dialog):
             # FileChooser.set_do_overwrite_confirmation() doesn't seem to
             # work on our custom dialog, so we use a simple alternative.
             if self._action == gtk.FILE_CHOOSER_ACTION_SAVE and os.path.exists(paths[0]):
-                overwrite_dialog = gtk.MessageDialog(None, 0,
-                                                     gtk.MESSAGE_QUESTION, gtk.BUTTONS_OK_CANCEL,
-                                                     _("A file named '%s' already exists. Do you want to replace it?") %
-                                                     os.path.basename(paths[0]))
+                overwrite_dialog = gtk.MessageDialog(None,
+                                                     0,
+                                                     gtk.MESSAGE_QUESTION,
+                                                     gtk.BUTTONS_OK_CANCEL,
+                                                     _("A file named '{}' already exists. "
+                                                       "Do you want to replace it?").format(os.path.basename(paths[0])))
                 overwrite_dialog.format_secondary_text(
                         _('Replacing it will overwrite its contents.'))
                 response = overwrite_dialog.run()
@@ -165,7 +167,7 @@ class _ComicFileChooserDialog(gtk.Dialog):
                 self._namelabel.set_text(encoding.to_unicode(
                         os.path.basename(path)))
                 self._sizelabel.set_text(
-                        '%.1f KiB' % (os.stat(path).st_size / 1024.0))
+                        '{:.1f} KiB'.format(os.stat(path).st_size / 1024.0))
         else:
             self._preview_image.clear()
             self._namelabel.set_text('')
@@ -229,7 +231,7 @@ class _LibraryFileChooserDialog(_ComicFileChooserDialog):
                                  self._set_collection_name)
 
         self._collection_button = gtk.CheckButton(
-                '%s:' % _('Automatically add the books to this collection'),
+                '{}:'.format(_('Automatically add the books to this collection')),
                 False)
         self._collection_button.set_active(
                 prefs['auto add books into collections'])

--- a/src/filehandler.py
+++ b/src/filehandler.py
@@ -230,7 +230,7 @@ class FileHandler(object):
         # (bad idea if it's permanently hidden; but no better way nearby)
         if not os.access(path, os.R_OK):
             self._window.statusbar.set_message(
-                    _('Could not open %s: Permission denied.') % path)
+                    _('Could not open {}: Permission denied.').format(path))
             return False
         if os.path.isdir(path):
             dir_path = path  # handle it as a directory later.
@@ -238,13 +238,11 @@ class FileHandler(object):
             # getting 'unknown type'.
         elif not os.path.isfile(path):  # ...not dir or normal file.
             self._window.statusbar.set_message(
-                    _('Could not open %s: No such file.') % path)
+                    _('Could not open {}: No such file.').format(path))
             return False
         self.archive_type = archive.archive_mime_type(path)
-        if self.archive_type is None and not is_image_file(path) and \
-                not dir_path:
-            self._window.statusbar.set_message(
-                    _('Could not open %s: Unknown file type.') % path)
+        if self.archive_type is None and not is_image_file(path) and not dir_path:
+            self._window.statusbar.set_message(_('Could not open {}: Unknown file type.').format(path))
             return False
 
         # We close the previously opened file.
@@ -332,8 +330,8 @@ class FileHandler(object):
                 self._redo_priority_ordering(start_page, self._image_files)
 
         if not self._image_files:
-            self._window.statusbar.set_message(_("No images or subarchives in '%s'") %
-                                               os.path.basename(path))
+            self._window.statusbar.set_message(_("No images or subarchives in '{}'").format(
+                                               os.path.basename(path)))
             self.file_loaded = False
         else:
             self.file_loaded = True
@@ -446,7 +444,7 @@ class FileHandler(object):
         archives by their filename.
         """
         exts = '|'.join(prefs['comment extensions'])
-        self._comment_re = re.compile(r'\.(%s)\s*$' % exts, re.I)
+        self._comment_re = re.compile(r'\.({})\s*$'.format(exts), re.I)
 
     def get_path_to_page(self, page=None):
         """Return the full path to the image file for <page>, or the current

--- a/src/library.py
+++ b/src/library.py
@@ -72,7 +72,7 @@ class _LibraryDialog(gtk.Window):
         there earlier.
         """
         self._statusbar.pop(0)
-        self._statusbar.push(0, ' %s' % encoding.to_unicode(message))
+        self._statusbar.push(0, u' {}'.format(encoding.to_unicode(message)))
 
     def close(self, *args):
         """Close the library and do required cleanup tasks."""
@@ -199,7 +199,7 @@ class _CollectionArea(gtk.ScrolledWindow):
         expanded_collections = []
         self._treeview.map_expanded_rows(_expanded_rows_accumulator)
         self._treestore.clear()
-        self._treestore.append(None, ['<b>%s</b>' % xmlescape(_('All books')),
+        self._treestore.append(None, ['<b>{}</b>'.format(xmlescape(_('All books'))),
                                       _COLLECTION_ALL])
         _recursive_add(None, None)
         self._treestore.foreach(_expand_and_select)
@@ -269,10 +269,9 @@ class _CollectionArea(gtk.ScrolledWindow):
             if self._library.backend.rename_collection(collection, new_name):
                 self.display_collections()
             else:
-                message = _("Could not change the name to '%s'.") % new_name
+                message = _("Could not change the name to '{}'.").format(new_name)
                 if self._library.backend.get_collection_by_name(new_name) is not None:
-                    message = '%s %s' % (message,
-                                         _('A collection by that name already exists.'))
+                    message = '{} {}'.format(message, _('A collection by that name already exists.'))
                 self._library.set_status_message(message)
 
     def _duplicate_collection(self, action):
@@ -380,10 +379,9 @@ class _CollectionArea(gtk.ScrolledWindow):
             if dest_collection is None:
                 dest_name = _('Root')
             else:
-                dest_name = self._library.backend.get_collection_name(
-                        dest_collection)
-            message = (_("Put the collection '%(subcollection)s' in the collection '%(supercollection)s'.") %
-                       {'subcollection': src_name, 'supercollection': dest_name})
+                dest_name = self._library.backend.get_collection_name(dest_collection)
+            message = _("Put the collection '{subcollection}' in the collection '{supercollection}'.") \
+                .format(subcollection=src_name, supercollection=dest_name)
         else:  # Moving book(s).
             if drop_row is None:
                 self._set_acceptable_drop(False)
@@ -402,13 +400,13 @@ class _CollectionArea(gtk.ScrolledWindow):
             dest_name = self._library.backend.get_collection_name(
                     dest_collection)
             if src_collection == _COLLECTION_ALL:
-                message = _("Add books to '%s'.") % dest_name
+                message = _("Add books to '{}'.").format(dest_name)
             else:
-                src_name = self._library.backend.get_collection_name(
-                        src_collection)
-                message = (_("Move books from '%(source collection)s' to '%(destination collection)s'.") %
-                           {'source collection': src_name,
-                            'destination collection': dest_name})
+                src_name = self._library.backend.get_collection_name(src_collection)
+
+                message = (_("Move books from '{source collection}' to '{destination collection}'.")
+                           .format(**{'source collection': src_name,
+                                      'destination collection': dest_name}))
         self._set_acceptable_drop(True)
         self._library.set_status_message(message)
 
@@ -583,8 +581,7 @@ class _BookArea(gtk.ScrolledWindow):
             self.remove_book_at_path(path)
         coll_name = self._library.backend.get_collection_name(collection)
         self._library.set_status_message(
-                _("Removed %(num)d book(s) from '%(collection)s'.") %
-                {'num': len(selected), 'collection': coll_name})
+                _("Removed {num} book(s) from '{collection}'.").format(num=len(selected), collection=coll_name))
 
     def _remove_books_from_library(self, *args):
         """Remove the currently selected book(s) from the library, and thus
@@ -606,7 +603,7 @@ class _BookArea(gtk.ScrolledWindow):
                 self._library.backend.remove_book(book)
                 self.remove_book_at_path(path)
             self._library.set_status_message(
-                    _('Removed %d book(s) from the library.') % len(selected))
+                    _('Removed {} book(s) from the library.').format(len(selected)))
 
     def _button_press(self, iconview, event):
         """Handle mouse button presses on the _BookArea."""
@@ -765,7 +762,7 @@ class _ControlArea(gtk.HBox):
         self.pack_start(vbox, True, True)
         hbox = gtk.HBox(False)
         vbox.pack_start(hbox, False, False)
-        label = gtk.Label('%s:' % _('Search'))
+        label = gtk.Label('{}:'.format(_('Search')))
         hbox.pack_start(label, False, False)
         search_entry = gtk.Entry()
         search_entry.connect('activate', self._filter_books)
@@ -774,7 +771,7 @@ class _ControlArea(gtk.HBox):
                                         'full path. The search is not case '
                                         'sensitive.'))
         hbox.pack_start(search_entry, True, True, 6)
-        label = gtk.Label('%s:' % _('Cover size'))
+        label = gtk.Label('{}:'.format(_('Cover size')))
         hbox.pack_start(label, False, False, 6)
         adjustment = gtk.Adjustment(prefs['library cover size'], 50, 128, 1,
                                     10, 0)
@@ -830,12 +827,12 @@ class _ControlArea(gtk.HBox):
         else:
             self._namelabel.set_text('')
         if pages is not None:
-            self._pageslabel.set_text(_('%d pages') % pages)
+            self._pageslabel.set_text(_('{} pages').format(pages))
         else:
             self._pageslabel.set_text('')
         if format_ is not None and size is not None:
-            self._filelabel.set_text('%s, %s' % (archive.get_name(format_),
-                                                 '%.1f MiB' % (size / 1048576.0)))
+            self._filelabel.set_text('{}, {}'.format(archive.get_name(format_),
+                                                     '{:.1f} MiB'.format(size / 1048576.0)))
         else:
             self._filelabel.set_text('')
         if dir_path is not None:
@@ -874,11 +871,9 @@ class _ControlArea(gtk.HBox):
                 prefs['last library collection'] = collection
                 self._library.collection_area.display_collections()
             else:
-                message = _("Could not add a new collection called '%s'.") % (
-                    name)
+                message = _("Could not add a new collection called '{}'.") .format(name)
                 if self._library.backend.get_collection_by_name(name) is not None:
-                    message = '%s %s' % (message,
-                                         _('A collection by that name already exists.'))
+                    message = '{} {}'.format(message, _('A collection by that name already exists.'))
                 self._library.set_status_message(message)
 
     def _filter_books(self, entry, *args):
@@ -926,7 +921,7 @@ class _AddBooksProgressDialog(gtk.Dialog):
         hbox.pack_start(left_box, False, False)
         hbox.pack_start(right_box, False, False)
 
-        label = labels.BoldLabel('%s:' % _('Added books'))
+        label = labels.BoldLabel('{}:'.format(_('Added books')))
         label.set_alignment(1.0, 1.0)
         left_box.pack_start(label, True, True)
         number_label = gtk.Label('0')
@@ -947,9 +942,8 @@ class _AddBooksProgressDialog(gtk.Dialog):
         for i, path in enumerate(paths):
             if library.backend.add_book(path, collection):
                 total_added += 1
-                number_label.set_text('%d' % total_added)
-            added_label.set_text(_("Adding '%s'...") %
-                                 encoding.to_unicode(path))
+                number_label.set_text('{:d}'.format(total_added))
+            added_label.set_text(_("Adding '{}'...").format(encoding.to_unicode(path)))
             bar.set_fraction((i + 1) / total_paths)
             while gtk.events_pending():
                 gtk.main_iteration(False)

--- a/src/main.py
+++ b/src/main.py
@@ -723,18 +723,16 @@ class MainWindow(gtk.Window):
     def update_title(self):
         """Set the title acording to current state."""
         if self.displayed_double():
-            title = encoding.to_unicode('[%d,%d / %d]  %s - Comix' % (
-                self.file_handler.get_current_page(),
-                self.file_handler.get_current_page() + 1,
-                self.file_handler.get_number_of_pages(),
-                self.file_handler.get_pretty_current_filename()))
+            title = encoding.to_unicode('[{:d},{:d} / {:d}]  {} - Comix'.format(self.file_handler.get_current_page(),
+                                                                                self.file_handler.get_current_page() + 1,
+                                                                                self.file_handler.get_number_of_pages(),
+                                                                                self.file_handler.get_pretty_current_filename()))
         else:
-            title = encoding.to_unicode('[%d / %d]  %s - Comix' % (
-                self.file_handler.get_current_page(),
-                self.file_handler.get_number_of_pages(),
-                self.file_handler.get_pretty_current_filename()))
+            title = encoding.to_unicode('[{:d} / {:d}]  {} - Comix'.format(self.file_handler.get_current_page(),
+                                                                           self.file_handler.get_number_of_pages(),
+                                                                           self.file_handler.get_pretty_current_filename()))
         if self.slideshow.is_running():
-            title = '[%s] %s' % (_('SLIDESHOW'), title)
+            title = '[{}] {}'.format(_('SLIDESHOW'), title)
         self.set_title(title)
 
     def set_bg_colour(self, colour):

--- a/src/mobiunpack.py
+++ b/src/mobiunpack.py
@@ -27,7 +27,7 @@ class Sectionizer(object):
         self.ident = header[0x3C:0x3C + 8]
         self.num_sections, = struct.unpack_from('>H', header, 76)
         sections = self.f.read(self.num_sections * 8)
-        self.sections = struct.unpack_from('>%dL' % (self.num_sections * 2), sections, 0)[::2] + (0x7fffffff,)
+        self.sections = struct.unpack_from('>{}L'.format(self.num_sections * 2), sections, 0)[::2] + (0x7fffffff,)
 
     def loadSection(self, section, limit=0x7fffffff):
         before, after = self.sections[section:section + 2]
@@ -62,7 +62,7 @@ class MobiFile(object):
             header = self.sect.loadSection(i, 32)
             imgtype = imghdr.what(None, header)
             if imgtype is not None:
-                names.append("image%05d.%s" % (1 + i - self.firstimg, imgtype))
+                names.append("image{:05d}.{}".format(1 + i - self.firstimg, imgtype))
         return names
 
     def extract(self, name, dst):

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -98,8 +98,8 @@ class _PreferencesDialog(gtk.Dialog):
         # ----------------------------------------------------------------
         page = _PreferencePage(80)
         page.new_section(_('Background'))
-        fixed_bg_button = gtk.RadioButton(None, '%s:' %
-                                          _('Use this colour as background'))
+        fixed_bg_button = gtk.RadioButton(None, '{}:'
+                                          .format(_('Use this colour as background')))
         fixed_bg_button.set_tooltip_text(
                 _('Always use this selected colour as the background colour.'))
         color_button = gtk.ColorButton(gtk.gdk.Color(*prefs['bg colour']))
@@ -114,7 +114,7 @@ class _PreferencesDialog(gtk.Dialog):
         page.add_row(dynamic_bg_button)
 
         page.new_section(_('Thumbnails'))
-        label = gtk.Label('%s:' % _('Thumbnail size (in pixels)'))
+        label = gtk.Label('{}:'.format(_('Thumbnail size (in pixels)')))
         adjustment = gtk.Adjustment(prefs['thumbnail size'], 20, 128, 1, 10)
         thumb_size_spinner = gtk.SpinButton(adjustment)
         thumb_size_spinner.connect('value_changed', self._spinner_cb,
@@ -129,7 +129,7 @@ class _PreferencesDialog(gtk.Dialog):
         page.add_row(thumb_number_button)
 
         page.new_section(_('Magnifying Glass'))
-        label = gtk.Label('%s:' % _('Magnifying glass size (in pixels)'))
+        label = gtk.Label('{}:'.format(_('Magnifying glass size (in pixels)')))
         adjustment = gtk.Adjustment(prefs['lens size'], 50, 400, 1, 10)
         glass_size_spinner = gtk.SpinButton(adjustment)
         glass_size_spinner.connect('value_changed', self._spinner_cb,
@@ -137,7 +137,7 @@ class _PreferencesDialog(gtk.Dialog):
         glass_size_spinner.set_tooltip_text(
                 _('Set the size of the magnifying glass. It is a square with a side of this many pixels.'))
         page.add_row(label, glass_size_spinner)
-        label = gtk.Label('%s:' % _('Magnification factor'))
+        label = gtk.Label('{}:'.format(_('Magnification factor')))
         adjustment = gtk.Adjustment(prefs['lens magnification'], 1.1, 10.0,
                                     0.1, 1.0)
         glass_magnification_spinner = gtk.SpinButton(adjustment, digits=1)
@@ -300,7 +300,7 @@ class _PreferencesDialog(gtk.Dialog):
         manga_button.connect('toggled', self._check_button_cb,
                              'default manga mode')
         page.add_row(manga_button)
-        label = gtk.Label('%s:' % _('Default zoom mode'))
+        label = gtk.Label('{}:'.format(_('Default zoom mode')))
         zoom_combo = gtk.combo_box_new_text()
         zoom_combo.append_text(_('Best fit mode'))
         zoom_combo.append_text(_('Fit width mode'))
@@ -320,7 +320,7 @@ class _PreferencesDialog(gtk.Dialog):
         page.add_row(hide_in_fullscreen_button)
 
         page.new_section(_('Slideshow'))
-        label = gtk.Label('%s:' % _('Slideshow delay (in seconds)'))
+        label = gtk.Label('{}:'.format(_('Slideshow delay (in seconds)')))
         adjustment = gtk.Adjustment(prefs['slideshow delay'] / 1000.0,
                                     0.5, 3600.0, 0.1, 1)
         delay_spinner = gtk.SpinButton(adjustment, digits=1)
@@ -329,7 +329,7 @@ class _PreferencesDialog(gtk.Dialog):
         page.add_row(label, delay_spinner)
 
         page.new_section(_('Comments'))
-        label = gtk.Label('%s:' % _('Comment extensions'))
+        label = gtk.Label('{}:'.format(_('Comment extensions')))
         extensions_entry = gtk.Entry()
         extensions_entry.set_text(', '.join(prefs['comment extensions']))
         extensions_entry.connect('activate', self._entry_cb)

--- a/src/properties.py
+++ b/src/properties.py
@@ -80,7 +80,7 @@ class _Page(gtk.VBox):
         hbox.pack_start(left_box, False, False)
         hbox.pack_start(right_box, False, False)
         for desc, value in info:
-            desc_label = labels.BoldLabel('%s:' % desc)
+            desc_label = labels.BoldLabel('{}:'.format(desc))
             desc_label.set_alignment(1.0, 1.0)
             left_box.pack_start(desc_label, True, True)
             value_label = gtk.Label(value)
@@ -116,11 +116,10 @@ class _PropertiesDialog(gtk.Dialog):
             try:
                 stats = os.stat(window.file_handler.get_path_to_base())
                 main_info = (
-                    _('%d pages') % window.file_handler.get_number_of_pages(),
-                    _('%d comments') %
-                    window.file_handler.get_number_of_comments(),
+                    _('{:d} pages').format window.file_handler.get_number_of_pages(),
+                    _('{:d} comments').format(window.file_handler.get_number_of_comments()),
                     archive.get_name(window.file_handler.archive_type),
-                    '%.1f MiB' % (stats.st_size / 1048576.0))
+                    '{:.1f} MiB'.format(stats.st_size / 1048576.0))
                 page.set_main_info(main_info)
                 try:
                     uid = pwd.getpwuid(stats.st_uid)[0]
@@ -153,9 +152,9 @@ class _PropertiesDialog(gtk.Dialog):
             stats = os.stat(path)
             width, height = window.file_handler.get_size()
             main_info = (
-                '%dx%d px' % (width, height),
+                '{:d}x{:d} px'.format(width, height),
                 window.file_handler.get_mime_name(),
-                '%.1f KiB' % (stats.st_size / 1024.0))
+                '{:.1f} KiB'.format(stats.st_size / 1024.0))
             page.set_main_info(main_info)
             try:
                 uid = pwd.getpwuid(stats.st_uid)[0]

--- a/src/properties.py
+++ b/src/properties.py
@@ -116,7 +116,7 @@ class _PropertiesDialog(gtk.Dialog):
             try:
                 stats = os.stat(window.file_handler.get_path_to_base())
                 main_info = (
-                    _('{:d} pages').format window.file_handler.get_number_of_pages(),
+                    _('{:d} pages').format(window.file_handler.get_number_of_pages()),
                     _('{:d} comments').format(window.file_handler.get_number_of_comments()),
                     archive.get_name(window.file_handler.archive_type),
                     '{:.1f} MiB'.format(stats.st_size / 1048576.0))

--- a/src/status.py
+++ b/src/status.py
@@ -22,14 +22,14 @@ class Statusbar(gtk.Statusbar):
         replacing whatever was there earlier.
         """
         self.pop(0)
-        self.push(0, ' %s' % encoding.to_unicode(message))
+        self.push(0, u' {}'.format(encoding.to_unicode(message)))
 
     def set_page_number(self, page, total, double_page=False):
         """Update the page number."""
         if double_page:
-            self._page_info = '%d,%d / %d' % (page, page + 1, total)
+            self._page_info = '{:d},{:d} / {:d}'.format(page, page + 1, total)
         else:
-            self._page_info = '%d / %d' % (page, total)
+            self._page_info = '{:d} / {:d}'.format(page, total)
 
     def set_resolution(self, left_dimensions, right_dimensions=None):
         """Update the resolution data.
@@ -38,9 +38,9 @@ class Statusbar(gtk.Statusbar):
         resolution of an image as well as the currently displayed scale
         in percent.
         """
-        self._resolution = '%dx%d (%.1f%%)' % left_dimensions
+        self._resolution = '{:d}x{:d} ({:.1f}%)'.format(*left_dimensions)
         if right_dimensions is not None:
-            self._resolution += ', %dx%d (%.1f%%)' % right_dimensions
+            self._resolution += ', {:d}x{:d} ({:.1f}%)'.format(*right_dimensions)
 
     def set_root(self, root):
         """Set the name of the root (directory or archive)."""
@@ -53,5 +53,7 @@ class Statusbar(gtk.Statusbar):
     def update(self):
         """Set the statusbar to display the current state."""
         self.pop(0)
-        self.push(0, ' %s      |      %s      |      %s      |      %s' %
-                  (self._page_info, self._resolution, self._root, self._filename))
+        self.push(0, ' {}      |      {}      |      {}      |      {}'.format(self._page_info,
+                                                                               self._resolution,
+                                                                               self._root,
+                                                                               self._filename))

--- a/src/thumbnail.py
+++ b/src/thumbnail.py
@@ -152,7 +152,7 @@ def _create_thumbnail(path, dst_dir, image_path=None):
         'tEXt::Thumb::Mimetype': mime,
         'tEXt::Thumb::Image::Width': width,
         'tEXt::Thumb::Image::Height': height,
-        'tEXt::Software': 'Comix %s' % constants.VERSION
+        'tEXt::Software': 'Comix {}'.format(constants.VERSION)
     }
     try:
         if not os.path.isdir(dst_dir):

--- a/src/thumbremover.py
+++ b/src/thumbremover.py
@@ -66,21 +66,21 @@ class _ThumbnailMaintenanceDialog(gtk.Dialog):
         hbox.pack_start(left_box, False, False)
         hbox.pack_start(right_box, False, False)
 
-        label = labels.BoldLabel('%s:' % _('Thumbnail directory'))
+        label = labels.BoldLabel('{}:'.format(_('Thumbnail directory')))
         label.set_alignment(1.0, 1.0)
         left_box.pack_start(label, True, True)
-        label = gtk.Label('%s' % encoding.to_unicode(_thumb_base))
+        label = gtk.Label(u'{}'.format(encoding.to_unicode(_thumb_base)))
         label.set_alignment(0, 1.0)
         right_box.pack_start(label, True, True)
 
-        label = labels.BoldLabel('%s:' % _('Total number of thumbnails'))
+        label = labels.BoldLabel('{}:'.format(_('Total number of thumbnails')))
         label.set_alignment(1.0, 1.0)
         left_box.pack_start(label, True, True)
         self._num_thumbs_label = gtk.Label(_('Calculating...'))
         self._num_thumbs_label.set_alignment(0, 1.0)
         right_box.pack_start(self._num_thumbs_label, True, True)
 
-        label = labels.BoldLabel('%s:' % _('Total size of thumbnails'))
+        label = labels.BoldLabel('{}:'.format(_('Total size of thumbnails')))
         label.set_alignment(1.0, 1.0)
         left_box.pack_start(label, True, True)
         self._size_thumbs_label = gtk.Label(_('Calculating...'))
@@ -108,8 +108,8 @@ class _ThumbnailMaintenanceDialog(gtk.Dialog):
                     if os.path.isfile(entry_path):
                         self._num_thumbs += 1
                         size_thumbs += os.stat(entry_path).st_size
-        self._num_thumbs_label.set_text('%d' % self._num_thumbs)
-        self._size_thumbs_label.set_text('%.1f MiB' % (size_thumbs / 1048576.0))
+        self._num_thumbs_label.set_text('{:d}'.format(self._num_thumbs))
+        self._size_thumbs_label.set_text('{:.1f} MiB'.format(size_thumbs / 1048576.0))
 
     def _response(self, dialog, response):
         if response == gtk.RESPONSE_OK:
@@ -143,14 +143,14 @@ class _ThumbnailRemover(gtk.Dialog):
         hbox.pack_start(left_box, False, False)
         hbox.pack_start(right_box, False, False)
 
-        label = labels.BoldLabel('%s:' % _('Number of removed thumbnails'))
+        label = labels.BoldLabel('{}:'.format(_('Number of removed thumbnails')))
         label.set_alignment(1.0, 1.0)
         left_box.pack_start(label, True, True)
         number_label = gtk.Label('0')
         number_label.set_alignment(0, 1.0)
         right_box.pack_start(number_label, True, True)
 
-        label = labels.BoldLabel('%s:' % _('Total size of removed thumbnails'))
+        label = labels.BoldLabel('{}:'.format(_('Total size of removed thumbnails')))
         label.set_alignment(1.0, 1.0)
         left_box.pack_start(label, True, True)
         size_label = gtk.Label('0.0 MiB')
@@ -204,14 +204,13 @@ class _ThumbnailRemover(gtk.Dialog):
                         continue
                     removed_thumbs += 1
                     thumbs_size += size
-                    number_label.set_text('%d' % removed_thumbs)
-                    size_label.set_text('%.1f MiB' % (thumbs_size / 1048576.0))
+                    number_label.set_text('{:d}'.format(removed_thumbs))
+                    size_label.set_text('{:.1f} MiB'.format(thumbs_size / 1048576.0))
                     if broken:
                         src_path = '?'
                     else:
                         src_path = encoding.to_unicode(src_path)
-                    removing_label.set_text(_("Removed thumbnail for '%s'") %
-                                            src_path)
+                    removing_label.set_text(_("Removed thumbnail for '{}'".format(src_path)))
                 if iteration % 50 == 0:
                     bar.set_fraction(min(1, iteration / self._total_thumbs))
                 while gtk.events_pending():


### PR DESCRIPTION
Converts % formatting to `.format()`.  This has an effect on the translations.  I have updated all the *.po files but the *.mo files will need to be regenerated.  I am not as familiar with gettext as I probably should be to do this commit.  I believe that the the workflow is that individual language files (.po) are create off the .pot file and then customized.  The .mo are a generated binary file that the application looks up based on the systems LANG or LC_MESSAGES.  Please correct me if I am wrong!  